### PR TITLE
Run migrations automatically on app start in production

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,7 @@ config :logger, :console,
 
 config :prediction_analyzer, ecto_repos: [Predictions.Repo]
 config :prediction_analyzer, aws_requestor: ExAws
+config :prediction_analyzer, :migration_task, Predictions.ReleaseTasks.NoOp
 
 config :prediction_analyzer, Predictions.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -27,6 +27,8 @@ config :prediction_analyzer, Predictions.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool_size: 15
 
+config :prediction_analyzer, :migration_task, Predictions.ReleaseTasks
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/lib/prediction_analyzer/application.ex
+++ b/lib/prediction_analyzer/application.ex
@@ -1,6 +1,7 @@
 defmodule PredictionAnalyzer.Application do
   use Application
   alias Predictions.Utilities.Config
+  require Logger
 
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
@@ -22,7 +23,15 @@ defmodule PredictionAnalyzer.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: PredictionAnalyzer.Supervisor]
-    Supervisor.start_link(children, opts)
+    case Supervisor.start_link(children, opts) do
+      {:ok, _} = success ->
+        Logger.info("Started application, running migrations")
+        Application.get_env(:prediction_analyzer, :migration_task).migrate()
+        success
+
+      error ->
+        error
+    end
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/predictions/release_tasks.ex
+++ b/lib/predictions/release_tasks.ex
@@ -1,0 +1,17 @@
+defmodule Predictions.ReleaseTasks do
+  @moduledoc "Tasks that need to be run on app startup"
+
+  alias Predictions.Repo
+  alias Ecto.Migrator
+
+  def migrate do
+    migrations_path = Application.app_dir(:prediction_analyzer, "priv/repo/migrations")
+    Migrator.run(Repo, migrations_path, :up, all: true)
+  end
+end
+
+defmodule Predictions.ReleaseTasks.NoOp do
+  @moduledoc "Don't do any migrations on non-prod application starts"
+
+  def migrate, do: nil
+end


### PR DESCRIPTION
This copies the approach from Alerts Concierge. I intended this to be a part of #3 but committed to the wrong branch. :-/