### PR TITLE
Watch for vehicle movements and save arrivals/departures to DB

### DIFF
--- a/lib/prediction_analyzer/vehicle_events/vehicle_event.ex
+++ b/lib/prediction_analyzer/vehicle_events/vehicle_event.ex
@@ -1,0 +1,24 @@
+defmodule PredictionAnalyzer.VehicleEvents.VehicleEvent do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "vehicle_events" do
+    field(:vehicle_id, :string)
+    field(:vehicle_label, :string)
+    field(:is_deleted, :boolean)
+    field(:route_id, :string)
+    field(:direction_id, :integer)
+    field(:trip_id, :string)
+    field(:stop_id, :string)
+    field(:arrival_time, :integer)
+    field(:departure_time, :integer)
+  end
+
+  def changeset(vehicle_event, params \\ %{}) do
+    fields = [:vehicle_id, :vehicle_label, :is_deleted, :route_id, :direction_id, :trip_id, :stop_id, :arrival_time]
+    vehicle_event
+    |> cast(params, fields)
+    |> validate_required(fields)
+  end
+end

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -1,0 +1,100 @@
+defmodule PredictionAnalyzer.VehiclePositions.Comparator do
+  @moduledoc """
+  Compare the new set of vehicles to the old ones, to determine
+  which ones have arrived at or departed from a station.
+  """
+
+  require Logger
+  alias PredictionAnalyzer.VehiclePositions.Tracker
+  alias PredictionAnalyzer.VehiclePositions.Vehicle
+  alias PredictionAnalyzer.VehicleEvents.VehicleEvent
+  alias PredictionAnalyzer.Repo
+  import Ecto.Query, only: [from: 2]
+
+  @spec compare(Tracker.vehicle_map(), Tracker.vehicle_map()) :: Tracker.vehicle_map()
+  def compare(new_vehicles, old_vehicles) do
+    Enum.each(new_vehicles, fn {_id, new_vehicle} ->
+      compare_vehicle(new_vehicle, old_vehicles[new_vehicle.id])
+    end)
+
+    new_vehicles
+  end
+
+  defp compare_vehicle(
+         %Vehicle{stop_id: new_stop, current_status: new_status} = vehicle,
+         %Vehicle{stop_id: old_stop, current_status: old_status}
+       )
+       when new_stop == old_stop and new_status == :STOPPED_AT and old_status != :STOPPED_AT do
+    record_arrival(vehicle)
+  end
+
+  defp compare_vehicle(
+         %Vehicle{stop_id: new_stop, current_status: new_status},
+         %Vehicle{stop_id: old_stop, current_status: old_status} = old_vehicle
+       )
+       when new_stop != old_stop and old_status == :STOPPED_AT and new_status != :STOPPED_AT do
+    record_departure(old_vehicle)
+  end
+
+  defp compare_vehicle(%Vehicle{label: label}, nil) do
+    Logger.info("Tracking new vehicle #{label}")
+  end
+
+  defp compare_vehicle(_new, _old) do
+    nil
+  end
+
+  defp record_arrival(vehicle) do
+    params =
+      vehicle
+      |> vehicle_params()
+      |> Map.put(:arrival_time, vehicle.timestamp)
+
+    %VehicleEvent{}
+    |> VehicleEvent.changeset(params)
+    |> Repo.insert
+    |> case do
+      {:ok, _vehicle_event} ->
+        Logger.info("Inserted vehicle event: #{vehicle.label} arrived at #{vehicle.stop_id}")
+
+      {:error, changeset} ->
+        Logger.warn("Could not insert vehicle event: #{inspect(changeset)}")
+    end
+  end
+
+  defp record_departure(vehicle) do
+    from(
+      ve in VehicleEvent,
+      where: ve.vehicle_id == ^(vehicle.id)
+        and ve.stop_id == ^(vehicle.stop_id)
+        and is_nil(ve.departure_time)
+        and ve.arrival_time > ^(:os.system_time(:second) - 60*30),
+      update: [set: [departure_time: ^(vehicle.timestamp)]]
+    )
+    |> Repo.update_all([])
+    |> case do
+      {0, _} ->
+        Logger.warn("Tried to update departure time, but no arrival for #{vehicle.label}")
+
+      {1, _} ->
+        Logger.info("Added departure to vehicle event for #{vehicle.label}")
+
+      {_, _} ->
+        Logger.error("One departure, multiple updates for #{vehicle.label}")
+    end
+  end
+
+
+  @spec vehicle_params(Vehicle.t()) :: map()
+  defp vehicle_params(vehicle) do
+    %{
+      vehicle_id: vehicle.id,
+      vehicle_label: vehicle.label,
+      is_deleted: vehicle.is_deleted,
+      route_id: vehicle.route_id,
+      direction_id: vehicle.direction_id,
+      trip_id: vehicle.trip_id,
+      stop_id: vehicle.stop_id
+    }
+  end
+end

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -3,11 +3,14 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
 
   require Logger
   alias PredictionAnalyzer.VehiclePositions.Vehicle
+  alias PredictionAnalyzer.VehiclePositions.Comparator
+
+  @type vehicle_map :: %{Vehicle.vehicle_id => Vehicle.t()}
 
   @type t :: %{
     http_fetcher: module(),
     aws_vehicle_positions_url: String.t(),
-    vehicles: %{Vehicle.vehicle_id() => Vehicle.t()}
+    vehicles: vehicle_map()
   }
 
   def start_link(opts \\ []) do
@@ -38,6 +41,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
       |> Jason.decode!()
       |> parse_vehicles
       |> Enum.into(%{}, fn v -> {v.id, v} end)
+      |> Comparator.compare(state.vehicles)
     end)
 
     Logger.info("Processed #{length(Map.keys(new_vehicles))} vehicles in #{time/1000} ms")

--- a/lib/prediction_analyzer/vehicle_positions/vehicle.ex
+++ b/lib/prediction_analyzer/vehicle_positions/vehicle.ex
@@ -11,7 +11,8 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
     :route_id,
     :direction_id,
     :current_status,
-    :stop_id
+    :stop_id,
+    :timestamp
   ]
 
   defstruct @enforce_keys
@@ -25,7 +26,8 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
           trip_id: String.t(),
           route_id: String.t(),
           direction_id: 0 | 1,
-          current_status: :INCOMING_AT | :IN_TRANSIT_TO | :STOPPED_AT
+          current_status: :INCOMING_AT | :IN_TRANSIT_TO | :STOPPED_AT,
+          timestamp: integer()
         }
 
   @spec from_json(map()) :: {:ok, t()} | :error
@@ -34,6 +36,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
         "vehicle" => %{
           "current_status" => current_status,
           "stop_id" => stop_id,
+          "timestamp" => timestamp,
           "trip" => %{
             "direction_id" => direction_id,
             "route_id" => route_id,
@@ -47,7 +50,8 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
       })
       when is_boolean(is_deleted) and is_binary(stop_id) and is_binary(route_id) and
              is_binary(trip_id) and is_binary(id) and is_binary(label) and direction_id in [0, 1] and
-             current_status in ["INCOMING_AT", "IN_TRANSIT_TO", "STOPPED_AT"] do
+             current_status in ["INCOMING_AT", "IN_TRANSIT_TO", "STOPPED_AT"]
+             and is_integer(timestamp) do
 
     vehicle = %__MODULE__{
       id: id,
@@ -57,7 +61,8 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
       route_id: route_id,
       direction_id: direction_id,
       current_status: status_atom(current_status),
-      stop_id: stop_id
+      stop_id: stop_id,
+      timestamp: timestamp
     }
 
     {:ok, vehicle}

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -1,0 +1,62 @@
+defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
+  use ExUnit.Case
+  import Ecto.Query, only: [from: 2]
+  alias PredictionAnalyzer.VehicleEvents.VehicleEvent
+  alias PredictionAnalyzer.Repo
+  alias PredictionAnalyzer.VehiclePositions.Comparator
+  alias PredictionAnalyzer.VehiclePositions.Vehicle
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(PredictionAnalyzer.Repo)
+  end
+
+  @vehicle %Vehicle{
+    id: "1",
+    label: "1000",
+    is_deleted: false,
+    trip_id: "trip1",
+    route_id: "route1",
+    direction_id: 0,
+    current_status: :IN_TRANSIT_TO,
+    stop_id: "stop1",
+    timestamp: :os.system_time(:second)
+  }
+
+  describe "compare_vehicles" do
+    test "records arrival and departure of vehicle" do
+      assert Repo.one(from(ve in VehicleEvent, select: count(ve.id))) == 0
+
+      old_vehicles = %{
+        "1" => %{@vehicle | current_status: :INCOMING_AT}
+      }
+
+      new_vehicles = %{
+        "1" => %{@vehicle | current_status: :STOPPED_AT}
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      timestamp = @vehicle.timestamp
+
+      vehicle_events = Repo.all(from(ve in VehicleEvent, select: ve))
+
+      assert [
+        %VehicleEvent{vehicle_id: "1", arrival_time: ^timestamp, departure_time: nil}
+      ] = vehicle_events
+
+      ve_id = List.first(vehicle_events).id
+
+      old_vehicles = new_vehicles
+
+      new_vehicles = %{
+        "1" => %{@vehicle | current_status: :IN_TRANSIT_TO, stop_id: "stop2"}
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      assert [
+        %VehicleEvent{id: ^ve_id, vehicle_id: "1", arrival_time: ^timestamp, departure_time: ^timestamp}
+      ] =Repo.all(from(ve in VehicleEvent, select: ve))
+    end
+  end
+end

--- a/test/prediction_analyzer/vehicle_positions/tracker_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/tracker_test.exs
@@ -32,16 +32,15 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
       }
 
       assert {
-        :noreply,
-        %{vehicles: %{"R-5458F5AF" => %Vehicle{}}}
-      } = Tracker.handle_info(:track_vehicles, state)
-
+               :noreply,
+               %{vehicles: %{"R-5458F5AF" => %Vehicle{}}}
+             } = Tracker.handle_info(:track_vehicles, state)
     end
   end
 
   defmodule NotifyGet do
     def get!(url) do
-      send :tracker_test_listener, {:get, url}
+      send(:tracker_test_listener, {:get, url})
       %{body: Jason.encode!(%{"entity" => []})}
     end
   end
@@ -68,7 +67,7 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
                 "speed" => nil
               },
               "stop_id" => "70097",
-              "timestamp" => 1540242318,
+              "timestamp" => 1_540_242_318,
               "trip" => %{
                 "direction_id" => 0,
                 "route_id" => "Red",

--- a/test/prediction_analyzer/vehicle_positions/vehicle_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/vehicle_test.exs
@@ -21,7 +21,7 @@ defmodule PredictionAnalyzer.VehiclePositions.VehicleTest do
         "speed" => nil
       },
       "stop_id" => "70049",
-      "timestamp" => 1540391481,
+      "timestamp" => 1_540_391_481,
       "trip" => %{
         "direction_id" => 0,
         "route_id" => "Blue",
@@ -38,22 +38,21 @@ defmodule PredictionAnalyzer.VehiclePositions.VehicleTest do
     }
   }
 
-
   describe "from_json/1" do
     test "parses a correctly formed bit of JSON data" do
       assert {
-        :ok,
-        %Vehicle{
-          id: "B-5458FB84",
-          label: "0758",
-          is_deleted: false,
-          trip_id: "38078941",
-          route_id: "Blue",
-          direction_id: 0,
-          current_status: :INCOMING_AT,
-          stop_id: "70049"
-        }
-      } = Vehicle.from_json(@data)
+               :ok,
+               %Vehicle{
+                 id: "B-5458FB84",
+                 label: "0758",
+                 is_deleted: false,
+                 trip_id: "38078941",
+                 route_id: "Blue",
+                 direction_id: 0,
+                 current_status: :INCOMING_AT,
+                 stop_id: "70049"
+               }
+             } = Vehicle.from_json(@data)
     end
 
     test "returns :error if JSON can't be made into vehicle" do


### PR DESCRIPTION
Asana [(2) Logic in GenServer to compare new predictions to old, and log events](https://app.asana.com/0/584764604969369/876349910542899) and [(1) Update DB with vehicle events](https://app.asana.com/0/584764604969369/876349910542904).

This adds the `VehicleEvent` schema to query the `vehicle_events` table. It updates the logic of the VehiclePositions.Tracker to compare the old positions to the new, with a new `Comparator` module. If a given vehicle has changed its status to or from "STOPPED_AT" with the same or different stop_id, then we either create a new vehicle_event record for the arrival, or attempt to update an existing record with the departure time.