### PR TITLE
Associate new vehicle events with their predictions

### DIFF
--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -43,7 +43,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
     predictions =
       Enum.flat_map(entities, fn prediction ->
         trip_prediction = %{
-          trip_id: prediction["id"],
+          trip_id: prediction["trip_update"]["trip"]["trip_id"],
           is_deleted: prediction["is_deleted"]
         }
 

--- a/lib/prediction_analyzer/predictions/prediction.ex
+++ b/lib/prediction_analyzer/predictions/prediction.ex
@@ -1,5 +1,6 @@
 defmodule PredictionAnalyzer.Predictions.Prediction do
   use Ecto.Schema
+  alias PredictionAnalyzer.VehicleEvents.VehicleEvent
 
   schema "predictions" do
     field(:trip_id, :string)
@@ -12,5 +13,6 @@ defmodule PredictionAnalyzer.Predictions.Prediction do
     field(:stop_id, :string)
     field(:stop_sequence, :integer)
     field(:stops_away, :integer)
+    belongs_to(:vehicle_event, VehicleEvent)
   end
 end

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -2,6 +2,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
   use ExUnit.Case
   import Ecto.Query, only: [from: 2]
   alias PredictionAnalyzer.VehicleEvents.VehicleEvent
+  alias PredictionAnalyzer.Predictions.Prediction
   alias PredictionAnalyzer.Repo
   alias PredictionAnalyzer.VehiclePositions.Comparator
   alias PredictionAnalyzer.VehiclePositions.Vehicle
@@ -57,6 +58,47 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
       assert [
         %VehicleEvent{id: ^ve_id, vehicle_id: "1", arrival_time: ^timestamp, departure_time: ^timestamp}
       ] =Repo.all(from(ve in VehicleEvent, select: ve))
+    end
+
+    test "updates relevant predictions" do
+      prediction1 = %Prediction{
+        trip_id: "trip1",
+        arrival_time: :os.system_time(:second),
+        stop_id: "stop1"
+      }
+
+      prediction2 = %Prediction{
+        trip_id: "trip1",
+        arrival_time: :os.system_time(:second),
+        stop_id: "stop0"
+      }
+
+      prediction3 = %Prediction{
+        trip_id: "trip1",
+        arrival_time: :os.system_time(:second) - 24 * 60 * 60,
+        stop_id: "stop1"
+      }
+
+      [p1_id, p2_id, p3_id] = Enum.map([prediction1, prediction2, prediction3], fn prediction ->
+        Repo.insert!(prediction) |> Map.get(:id)
+      end)
+
+      vehicle = %{@vehicle | trip_id: "trip1", stop_id: "stop1"}
+
+      old_vehicles = %{
+        "1" => %{vehicle | current_status: :INCOMING_AT}
+      }
+
+      new_vehicles = %{
+        "1" => %{vehicle | current_status: :STOPPED_AT}
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      [ve_id] = Repo.all(from ve in VehicleEvent, select: ve.id)
+      assert Repo.one(from p in Prediction, where: p.id == ^p1_id, select: p.vehicle_event_id) == ve_id
+      assert Repo.one(from p in Prediction, where: p.id == ^p2_id, select: p.vehicle_event_id) == nil
+      assert Repo.one(from p in Prediction, where: p.id == ^p3_id, select: p.vehicle_event_id) == nil
     end
   end
 end


### PR DESCRIPTION
Asana tasks:
* [(4) When vehicle_event is created, update predictions table relevant rows with that new ID](https://app.asana.com/0/584764604969369/878909118663891)
* [(.5) Log a warning if no associated prediction](https://app.asana.com/0/584764604969369/878889370171877)

Uncovered a bug with how we were saving predictions: the `trip_id` isn't the GTFS entity ID, but rather buried in entity -> trip_update -> trip -> trip_id.

This PR associates new vehicle_events with their corresponding predictions, according to the algorithm in the asana ticket: matching stop_id and trip_id, with a time constraint. The asana ticket says "today", but I limited it to "arrival_time" OR "departure_time" predicted within 2 hours of now. (i.e. can't be off by more than 2 hours).

Ideally that time constraint will be against the prediction _file_ rather than this arrival OR departure thing, but that column is coming in a later ticket. I've left a note on that ticket saying it should update this where clause once we have that column.