### PR TITLE
Add vehicle_events to predictions page

### DIFF
--- a/lib/prediction_analyzer_web/controllers/predictions_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/predictions_controller.ex
@@ -6,7 +6,14 @@ defmodule PredictionAnalyzerWeb.PredictionsController do
 
   def index(conn, _params) do
     query =
-      from(p in Prediction, order_by: [:arrival_time, :departure_time], limit: 100)
+      from(
+        p in Prediction,
+        join: ve in assoc(p, :vehicle_event),
+        order_by: [desc: :arrival_time, desc: :departure_time],
+        limit: 100,
+        preload: [vehicle_event: ve],
+        select: p
+      )
 
     predictions = PredictionAnalyzer.Repo.all(query)
     render(conn, "index.html", predictions: predictions)

--- a/lib/prediction_analyzer_web/templates/predictions/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/predictions/index.html.eex
@@ -14,6 +14,8 @@
       <td>stop_id</td>
       <td>stop_sequence</td>
       <td>stops_away</td>
+      <td>actual arrival time</td>
+      <td>actual departure time</td>
     </tr>
 
     <%= for p <- @predictions do %>
@@ -28,6 +30,8 @@
       <td><%= p.stop_id %></td>
       <td><%= p.stop_sequence %></td>
       <td><%= p.stops_away %></td>
+      <td><%= p.vehicle_event && p.vehicle_event.arrival_time %></td>
+      <td><%= p.vehicle_event && p.vehicle_event.departure_time %></td>
     </tr>
     <% end %>
   </table>

--- a/test/prediction_analyzer_web/controllers/predictions_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/predictions_controller_test.exs
@@ -2,7 +2,19 @@ defmodule PredictionAnalyzerWeb.PredictionsControllerTest do
   use PredictionAnalyzerWeb.ConnCase
 
   test "GET /", %{conn: conn} do
-    conn = get(conn, "/predictions")
+    vehicle_event = %PredictionAnalyzer.VehicleEvents.VehicleEvent{
+      vehicle_id: "v1",
+      vehicle_label: "l1",
+      is_deleted: false,
+      route_id: "r1",
+      direction_id: 0,
+      trip_id: "TEST_TRIP",
+      stop_id: "70107",
+      arrival_time: 1000001,
+      departure_time: 1000002
+    }
+
+    {:ok, %{id: vehicle_event_id}} = PredictionAnalyzer.Repo.insert(vehicle_event)
 
     prediction = %PredictionAnalyzer.Predictions.Prediction{
       trip_id: "TEST_TRIP",
@@ -14,12 +26,17 @@ defmodule PredictionAnalyzerWeb.PredictionsControllerTest do
       schedule_relationship: "SCHEDULED",
       stop_id: "70107",
       stop_sequence: 310,
-      stops_away: 0
+      stops_away: 0,
+      vehicle_event_id: vehicle_event_id
     }
 
-    PredictionAnalyzer.Repo.insert(prediction)
+    PredictionAnalyzer.Repo.insert!(prediction)
 
-    response = html_response(conn, 200)
+    response =
+      conn
+      |> get("/predictions")
+      |> html_response(200)
+
     assert response =~ "trip_id"
     assert response =~ "is_deleted"
     assert response =~ "delay"
@@ -30,5 +47,8 @@ defmodule PredictionAnalyzerWeb.PredictionsControllerTest do
     assert response =~ "stop_id"
     assert response =~ "stop_sequence"
     assert response =~ "stops_away"
+    assert response =~ "TEST_TRIP"
+    assert response =~ "1000001"
+    assert response =~ "1000002"
   end
 end


### PR DESCRIPTION
Asana:
* [(1) Update the controller query of predictions page to join DB tables](https://app.asana.com/0/584764604969369/878909118663892)
* [(.5) Update the view to add new "actual" time column](https://app.asana.com/0/584764604969369/878909118663893)

Now that we have the `vehicle_event_id` FK on predictions, this updates the controller to join on it and show the combined data on the page.