### PR TITLE
Add file_timestamp to predictions and create prediction_accuracy table

### DIFF
--- a/priv/repo/migrations/20181026133153_add_file_timestamp_to_predictions.exs
+++ b/priv/repo/migrations/20181026133153_add_file_timestamp_to_predictions.exs
@@ -1,0 +1,11 @@
+defmodule PredictionAnalyzer.Repo.Migrations.AddFileTimestampToPredictions do
+  use Ecto.Migration
+
+  def change do
+    alter table("predictions") do
+      add :file_timestamp, :integer
+    end
+
+    create index("predictions", [:file_timestamp])
+  end
+end

--- a/priv/repo/migrations/20181026135330_create_prediction_accuracy_table.exs
+++ b/priv/repo/migrations/20181026135330_create_prediction_accuracy_table.exs
@@ -1,0 +1,27 @@
+defmodule PredictionAnalyzer.Repo.Migrations.CreatePredictionAccuracyTable do
+  use Ecto.Migration
+
+  def up do
+    execute("create type arrival_departure as enum ('arrival', 'departure')")
+    execute("create type prediction_bin as enum ('0-3 min', '3-6 min', '6-12 min', '12-30 min')")
+
+    create table("prediction_accuracy") do
+      add :service_date, :date, null: false
+      add :hour_of_day, :integer, null: false
+      add :stop_id, :string, null: false
+      add :route_id, :string, null: false
+      add :arrival_departure, :arrival_departure, null: false
+      add :bin, :prediction_bin, null: false
+      add :num_predictions, :integer, null: false
+      add :num_accurate_predictions, :integer, null: false
+    end
+
+    create index("prediction_accuracy", [:service_date])
+  end
+
+  def down do
+    drop table("prediction_accuracy")
+    execute("drop type prediction_bin")
+    execute("drop type arrival_departure")
+  end
+end


### PR DESCRIPTION
Asana: [(.5) Migration to add file timestamp column to predictions table and create prediction_accuracy table](https://app.asana.com/0/584764604969369/878889370171876).

I went back on forth on using a `timestamptz` data type for the predictions `file_timestamp` column, but in the end decided on `integer` since I imagine we populate that column from the `prediction.header.timestamp` field, which comes to us as an integer.

I added an index on the column, since our "associate `vehicle_event` with `prediction`" logic looks up recent predictions (and currently takes something like 6 seconds...).

Once the code is live that populates this column, we should truncate the table (since the data is worthless without it anyway), and then add a not-null constraint on the column.

For the prediction_accuracy table, I took advantage of postgres's `create type` functionality to add an enum type, so that the `bin` and `arrival_departure` columns get set and retrieved as a helpful string, but only take a byte to store and are quick to filter by.

Since Ecto lets you do it via `execute` but doesn't have a handy helper function for it, I couldn't stick it in `change` since it wouldn't know how to roll it back, so I made separate `up` and `down` functions.