### PR TITLE
Add PredictionAccuracy schema

### DIFF
--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -1,0 +1,34 @@
+defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "prediction_accuracy" do
+    field(:service_date, :date)
+    field(:hour_of_day, :integer)
+    field(:stop_id, :string)
+    field(:route_id, :string)
+    field(:arrival_departure, :string)
+    field(:bin, :string)
+    field(:num_predictions, :integer)
+    field(:num_accurate_predictions, :integer)
+  end
+
+  def new_insert_changeset(params \\ %{}) do
+    all_fields = [
+      :service_date,
+      :hour_of_day,
+      :stop_id,
+      :route_id,
+      :arrival_departure,
+      :bin,
+      :num_predictions,
+      :num_accurate_predictions
+    ]
+
+    %__MODULE__{}
+    |> cast(params, all_fields)
+    |> validate_required(all_fields)
+    |> validate_inclusion(:arrival_departure, ["arrival", "departure"])
+    |> validate_inclusion(:bin, ["0-3 min", "3-6 min", "6-12 min", "12-30 min"])
+  end
+end

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -1,0 +1,27 @@
+defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
+  use ExUnit.Case, async: true
+  alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
+
+
+  describe "new_insert_changeset/1" do
+    test "valid when fields are correct" do
+      changeset = PredictionAccuracy.new_insert_changeset(%{
+        service_date: "2015-01-01",
+        hour_of_day: 5,
+        stop_id: "stop1",
+        route_id: "route1",
+        arrival_departure: "arrival",
+        bin: "0-3 min",
+        num_predictions: 100,
+        num_accurate_predictions: 80
+      })
+
+      assert changeset.valid?
+    end
+
+    test "invalid when fields are not correct" do
+      changeset = PredictionAccuracy.new_insert_changeset(%{})
+      refute changeset.valid?
+    end
+  end
+end


### PR DESCRIPTION
Related to asana ticket [[5] We can see # of accurate and # of total predictions per stop per hour per bin](https://app.asana.com/0/584764604969369/878889370171875), but not any of its tasks in particular. Based on learnings from last sprint, we found that task inter-dependencies complicated working on the story in parallel. One of the hangups was the struct related to the table, which many of the tasks used. This PR introduces the struct in the hope of facilitating parallel work with fewer conflicts.