### PR TITLE
Add route_id column to predictions

### DIFF
--- a/priv/repo/migrations/20181029181739_add_route_id_to_predictions.exs
+++ b/priv/repo/migrations/20181029181739_add_route_id_to_predictions.exs
@@ -1,0 +1,9 @@
+defmodule PredictionAnalyzer.Repo.Migrations.AddRouteIdToPredictions do
+  use Ecto.Migration
+
+  def change do
+    alter table("predictions") do
+      add :route_id, :string
+    end
+  end
+end


### PR DESCRIPTION
We were missing this column. Per my slack message:

> PR 1 would be  a migration to add the column. PR 2 would be to update Download to populate it, and a migration to truncate everything in teh table, and make that column not null