### PR TITLE
Add filtering of prediction accuracy

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,7 @@ use Mix.Config
 # Configures the endpoint
 config :prediction_analyzer, PredictionAnalyzerWeb.Endpoint,
   url: [host: "localhost"],
-  secret_key_base: "local_secret_key_base",
+  secret_key_base: "local_secret_key_base_at_least_64_bytes_________________________________",
   render_errors: [view: PredictionAnalyzerWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: PredictionAnalyzer.PubSub, adapter: Phoenix.PubSub.PG2]
 

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -4,23 +4,19 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
 
   import Ecto.Query, only: [from: 2]
 
-  def index(conn, _params) do
-    relevant_predictions =
-      from(
-        acc in PredictionAccuracy,
-        where: acc.service_date == ^DateTime.to_date(Timex.local()) and acc.environment == "prod"
-      )
+  def index(conn, params) do
+    relevant_accuracies = PredictionAccuracy.filter(params["filters"] || %{})
 
     [num_accurate, num_predictions] =
       from(
-        acc in relevant_predictions,
+        acc in relevant_accuracies,
         select: [sum(acc.num_accurate_predictions), sum(acc.num_predictions)]
       )
       |> PredictionAnalyzer.Repo.one!()
 
     query =
       from(
-        acc in relevant_predictions,
+        acc in relevant_accuracies,
         order_by: [desc: :service_date, desc: :hour_of_day],
         limit: 100
       )

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -1,45 +1,92 @@
-<h1> Prediction Accuracy</h1>
+<div class="row">
+  <div class="col-xs-3">
+    <h3>Filters</h3>
 
-<div class="top-line-summary">
-  <div>
-    <span class="accuracy-summary-percentage">
-      <%= accuracy_percentage(@num_accurate, @num_predictions) %>
-    </span>
-    <span class="accuracy-summary-percent-sign">
-      %
-    </span>
-  </div>
-  <div>
-    From <%= @num_accurate %> accurate out of <%= @num_predictions %> total predictions
-  </div>
-</div>
+    <%= form_for @conn, accuracy_path(@conn, :index), [as: :filters, method: :get], fn f -> %>
+      <div class="form-group">
+        <%= label(f, :route_id, "Route ID") %>
+        <%= text_input(f, :route_id, class: "form-control") %>
+      </div>
 
-<div>
-  <table class="table">
-    <tr>
-      <th>Env</th>
-      <th>Service Date</th>
-      <th>Hour of Day</th>
-      <th>Stop id</th>
-      <th>Route id</th>
-      <th>Arrival/Departure</th>
-      <th>Bin</th>
-      <th>Number of predictions</th>
-      <th>Number of accurate predictions</th>
-    </tr>
+      <div class="form-group">
+        <%= label(f, :stop_id, "Stop ID") %>
+        <%= text_input(f, :stop_id, class: "form-control") %>
+      </div>
 
-    <%= for accuracy <- @accuracies do %>
-      <tr>
-        <td><%= accuracy.environment %>
-        <td><%= accuracy.service_date %></td>
-        <td><%= accuracy.hour_of_day %></td>
-        <td><%= accuracy.stop_id %></td>
-        <td><%= accuracy.route_id %></td>
-        <td><%= accuracy.arrival_departure %></td>
-        <td><%= accuracy.bin %></td>
-        <td><%= accuracy.num_predictions %></td>
-        <td><%= accuracy.num_accurate_predictions %></td>
-      </tr>
+      <div class="form-group">
+        <%= label(class: "radio-inline") do %>
+          <%= radio_button(f, :arrival_departure, "arrival") %> Arrivals
+        <% end %>
+
+        <%= label class: "radio-inline" do %>
+          <%= radio_button(f, :arrival_departure, "departure") %> Departures
+        <% end %>
+
+        <%= label class: "radio-inline" do %>
+          <%= radio_button(f, :arrival_departure, "all") %> All
+        <% end %>
+      </div>
+
+      <div class="form-group">
+        <%= label(f, :bin, "Bin") %>
+        <%= select(f, :bin, ["All" | Map.keys(PredictionAccuracy.bins())], class: "form-control") %>
+      </div>
+
+      <div class="form-group">
+        <%= label(f, :service_date, "Service Date") %>
+        <%= select(f, :service_date, service_dates(), class: "form-control") %>
+      </div>
+
+      <div class="form-group">
+        <%= submit "Filter", class: "btn btn-default" %>
+      </div>
+
     <% end %>
-  </table>
+  </div>
+
+  <div class="col-xs-9">
+    <h1> Prediction Accuracy</h1>
+
+    <div>
+      <div>
+        <span class="accuracy-summary-percentage">
+          <%= accuracy_percentage(@num_accurate, @num_predictions) %>
+        </span>
+        <span class="accuracy-summary-percent-sign">
+          %
+        </span>
+      </div>
+      <div>
+        From <%= @num_accurate %> accurate out of <%= @num_predictions %> total predictions
+      </div>
+    </div>
+
+    <table class="table">
+      <tr>
+        <th>Env</th>
+        <th>Service Date</th>
+        <th>Hour of Day</th>
+        <th>Stop id</th>
+        <th>Route id</th>
+        <th>Arrival/Departure</th>
+        <th>Bin</th>
+        <th>Number of predictions</th>
+        <th>Number of accurate predictions</th>
+      </tr>
+
+      <%= for accuracy <- @accuracies do %>
+        <tr>
+          <td><%= accuracy.environment %>
+          <td><%= accuracy.service_date %></td>
+          <td><%= accuracy.hour_of_day %></td>
+          <td><%= accuracy.stop_id %></td>
+          <td><%= accuracy.route_id %></td>
+          <td><%= accuracy.arrival_departure %></td>
+          <td><%= accuracy.bin %></td>
+          <td><%= accuracy.num_predictions %></td>
+          <td><%= accuracy.num_accurate_predictions %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
 </div>

--- a/lib/prediction_analyzer_web/templates/layout/app.html.eex
+++ b/lib/prediction_analyzer_web/templates/layout/app.html.eex
@@ -12,7 +12,7 @@
   </head>
 
   <body>
-    <div class="container">
+    <div class="container-fluid">
       <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
       <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
 

--- a/lib/prediction_analyzer_web/views/accuracy_view.ex
+++ b/lib/prediction_analyzer_web/views/accuracy_view.ex
@@ -1,5 +1,6 @@
 defmodule PredictionAnalyzerWeb.AccuracyView do
   use PredictionAnalyzerWeb, :view
+  alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
 
   def accuracy_percentage(num_accurate, num_predictions)
       when is_integer(num_accurate) and is_integer(num_predictions) and num_predictions != 0 do
@@ -8,5 +9,15 @@ defmodule PredictionAnalyzerWeb.AccuracyView do
 
   def accuracy_percentage(_, _) do
     0
+  end
+
+  def service_dates(now \\ Timex.local()) do
+    0..7
+    |> Enum.map(fn n ->
+      now
+      |> Timex.shift(days: -1 * n)
+      |> DateTime.to_date()
+      |> Date.to_string()
+    end)
   end
 end

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -43,4 +43,24 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
     assert response =~ "From 150 accurate out of 200 total predictions"
     assert response =~ "75.0"
   end
+
+  test "GET /accuracy with query params filter prediction accuracy statistics", %{conn: conn} do
+    a1 = %{@prediction_accuracy | num_accurate_predictions: 10, num_predictions: 20}
+
+    a2 = %{
+      @prediction_accuracy
+      | num_accurate_predictions: 20,
+        num_predictions: 20,
+        stop_id: "70121"
+    }
+
+    PredictionAnalyzer.Repo.insert!(a1)
+    PredictionAnalyzer.Repo.insert!(a2)
+
+    conn = get(conn, "/accuracy")
+    assert html_response(conn, 200) =~ "From 30 accurate out of 40 total predictions"
+
+    conn = get(conn, "/accuracy", %{"filters" => %{"stop_id" => "70120"}})
+    assert html_response(conn, 200) =~ "From 10 accurate out of 20 total predictions"
+  end
 end

--- a/test/prediction_analyzer_web/views/accuracy_view_test.exs
+++ b/test/prediction_analyzer_web/views/accuracy_view_test.exs
@@ -1,0 +1,19 @@
+defmodule PredictionAnalyzerWeb.AccuracyViewTest do
+  use PredictionAnalyzerWeb.ConnCase, async: true
+
+  test "service_dates/1" do
+    time = Timex.local() |> Timex.set(year: 2018, month: 10, day: 31)
+
+    assert PredictionAnalyzerWeb.AccuracyView.service_dates(time) ==
+             [
+               "2018-10-31",
+               "2018-10-30",
+               "2018-10-29",
+               "2018-10-28",
+               "2018-10-27",
+               "2018-10-26",
+               "2018-10-25",
+               "2018-10-24"
+             ]
+  end
+end


### PR DESCRIPTION
Asana: [[3] We can drill down into the accuracy metrics by attribute](https://app.asana.com/0/584764604969369/881339877158243).

Adds a form on the page that lets you filter by the specified attributes. The rows on the page reflect the filters, as does the accuracy summary on top. The form fields maintain their state based on the parameters in the URL.

![screen shot 2018-11-01 at 1 02 36 pm](https://user-images.githubusercontent.com/384428/47875062-84cad480-dde3-11e8-88ed-a14e2aab6bf9.png)
