### PR TITLE
Display hourly aggregates on page

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,8 @@ config :prediction_analyzer, PredictionAnalyzer.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "prediction_analyzer_repo"
 
+config :prediction_analyzer, start_workers: true
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,3 +22,5 @@ config :prediction_analyzer,
   aws_predictions_url: "https://prod.example.com/mbta-gtfs-s3/rtr/TripUpdates_enhanced.json",
   dev_green_aws_predictions_url:
     "https://dev_green.example.com/mbta-gtfs-s3/rtr/TripUpdates_enhanced.json"
+
+config :prediction_analyzer, start_workers: false

--- a/lib/prediction_analyzer/application.ex
+++ b/lib/prediction_analyzer/application.ex
@@ -19,26 +19,27 @@ defmodule PredictionAnalyzer.Application do
       # worker(PredictionAnalyzer.Worker, [arg1, arg2, arg3]),
     ]
 
-    workers = if Application.get_env(:prediction_analyzer, :start_workers) do
-      [
-        worker(
-          PredictionAnalyzer.VehiclePositions.Tracker,
-          [[environment: "dev-green"]],
-          id: DevGreenVehiclePositionsTracker
-        ),
-        worker(
-          PredictionAnalyzer.VehiclePositions.Tracker,
-          [[environment: "prod"]],
-          id: ProdVehiclePositionsTracker
-        ),
-        worker(PredictionAnalyzer.Predictions.Download, [
-          [name: PredictionAnalyzer.Predictions.Download]
-        ]),
-        worker(PredictionAnalyzer.PredictionAccuracy.Aggregator, []),
-      ]
-    else
-      []
-    end
+    workers =
+      if Application.get_env(:prediction_analyzer, :start_workers) do
+        [
+          worker(
+            PredictionAnalyzer.VehiclePositions.Tracker,
+            [[environment: "dev-green"]],
+            id: DevGreenVehiclePositionsTracker
+          ),
+          worker(
+            PredictionAnalyzer.VehiclePositions.Tracker,
+            [[environment: "prod"]],
+            id: ProdVehiclePositionsTracker
+          ),
+          worker(PredictionAnalyzer.Predictions.Download, [
+            [name: PredictionAnalyzer.Predictions.Download]
+          ]),
+          worker(PredictionAnalyzer.PredictionAccuracy.Aggregator, [])
+        ]
+      else
+        []
+      end
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -94,4 +94,25 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
         from(acc in q, where: acc.service_date == ^(Timex.local() |> DateTime.to_date()))
     end
   end
+
+  @doc """
+  Takes a Queryable and groups and sums the results into
+  a table like:
+
+  hour | prod total | prod accurate | dev-green total | dev-green accurate
+  """
+  def stats_by_environment_and_hour(q) do
+    from(
+      acc in q,
+      group_by: :hour_of_day,
+      order_by: :hour_of_day,
+      select: [
+        acc.hour_of_day,
+        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "prod", acc.num_predictions)),
+        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "prod", acc.num_accurate_predictions)),
+        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "dev-green", acc.num_predictions)),
+        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "dev-green", acc.num_accurate_predictions))
+      ]
+    )
+  end
 end

--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -108,10 +108,38 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
       order_by: :hour_of_day,
       select: [
         acc.hour_of_day,
-        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "prod", acc.num_predictions)),
-        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "prod", acc.num_accurate_predictions)),
-        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "dev-green", acc.num_predictions)),
-        sum(fragment("case when ? = ? then ? else 0 end", acc.environment, "dev-green", acc.num_accurate_predictions))
+        sum(
+          fragment(
+            "case when ? = ? then ? else 0 end",
+            acc.environment,
+            "prod",
+            acc.num_predictions
+          )
+        ),
+        sum(
+          fragment(
+            "case when ? = ? then ? else 0 end",
+            acc.environment,
+            "prod",
+            acc.num_accurate_predictions
+          )
+        ),
+        sum(
+          fragment(
+            "case when ? = ? then ? else 0 end",
+            acc.environment,
+            "dev-green",
+            acc.num_predictions
+          )
+        ),
+        sum(
+          fragment(
+            "case when ? = ? then ? else 0 end",
+            acc.environment,
+            "dev-green",
+            acc.num_accurate_predictions
+          )
+        )
       ]
     )
   end

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -1,4 +1,5 @@
 defmodule PredictionAnalyzerWeb.AccuracyController do
+  require Logger
   use PredictionAnalyzerWeb, :controller
   alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
 
@@ -14,14 +15,10 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
       )
       |> PredictionAnalyzer.Repo.one!()
 
-    query =
-      from(
-        acc in relevant_accuracies,
-        order_by: [desc: :service_date, desc: :hour_of_day],
-        limit: 100
-      )
-
-    accuracies = PredictionAnalyzer.Repo.all(query)
+    accuracies =
+      relevant_accuracies
+      |> PredictionAccuracy.stats_by_environment_and_hour()
+      |> PredictionAnalyzer.Repo.all()
 
     render(
       conn,

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -1,5 +1,4 @@
 defmodule PredictionAnalyzerWeb.AccuracyController do
-  require Logger
   use PredictionAnalyzerWeb, :controller
   alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
 

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -63,28 +63,20 @@
 
     <table class="table">
       <tr>
-        <th>Env</th>
-        <th>Service Date</th>
         <th>Hour of Day</th>
-        <th>Stop id</th>
-        <th>Route id</th>
-        <th>Arrival/Departure</th>
-        <th>Bin</th>
-        <th>Number of predictions</th>
-        <th>Number of accurate predictions</th>
+        <th>Prod Accuracy</th>
+        <th>Prod Total</th>
+        <th>Dev-Green Accuracy</th>
+        <th>Dev-Green Total</th>
       </tr>
 
-      <%= for accuracy <- @accuracies do %>
+      <%= for [hour, prod_total, prod_accurate, dg_total, dg_accurate] <- @accuracies do %>
         <tr>
-          <td><%= accuracy.environment %>
-          <td><%= accuracy.service_date %></td>
-          <td><%= accuracy.hour_of_day %></td>
-          <td><%= accuracy.stop_id %></td>
-          <td><%= accuracy.route_id %></td>
-          <td><%= accuracy.arrival_departure %></td>
-          <td><%= accuracy.bin %></td>
-          <td><%= accuracy.num_predictions %></td>
-          <td><%= accuracy.num_accurate_predictions %></td>
+          <td><%= hour %></td>
+          <td><%= accuracy_percentage(prod_accurate, prod_total) %>%</td>
+          <td><%= prod_total %></td>
+          <td><%= accuracy_percentage(dg_accurate, dg_total) %>%</td>
+          <td><%= dg_total %></td>
         </tr>
       <% end %>
     </table>

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -100,19 +100,19 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
                [11, 495, 472, 1095, 872]
              ]
     end
-
-    defp insert_accuracy(env, hour, total, accurate) do
-      PredictionAnalyzer.Repo.insert!(%{
-        @prediction_accuracy
-        | environment: env,
-          hour_of_day: hour,
-          num_predictions: total,
-          num_accurate_predictions: accurate
-      })
-    end
   end
 
   defp execute_query(q) do
     Repo.all(from(acc in q, order_by: :id))
+  end
+
+  defp insert_accuracy(env, hour, total, accurate) do
+    PredictionAnalyzer.Repo.insert!(%{
+      @prediction_accuracy
+      | environment: env,
+        hour_of_day: hour,
+        num_predictions: total,
+        num_accurate_predictions: accurate
+    })
   end
 end

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -96,20 +96,19 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
         |> Repo.all()
 
       assert stats == [
-        [10, 209, 201, 809, 701],
-        [11, 495, 472, 1095, 872]
-      ]
+               [10, 209, 201, 809, 701],
+               [11, 495, 472, 1095, 872]
+             ]
     end
 
     defp insert_accuracy(env, hour, total, accurate) do
-      PredictionAnalyzer.Repo.insert!(
-        %{@prediction_accuracy |
-          environment: env,
+      PredictionAnalyzer.Repo.insert!(%{
+        @prediction_accuracy
+        | environment: env,
           hour_of_day: hour,
           num_predictions: total,
-          num_accurate_predictions: accurate,
-        }
-      )
+          num_accurate_predictions: accurate
+      })
     end
   end
 

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -1,5 +1,5 @@
 defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
   alias PredictionAnalyzer.Repo
 
@@ -76,6 +76,40 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       q = from(acc in PredictionAccuracy.filter(%{"bin" => "6-12 min"}), [])
       assert [%{id: ^acc5_id}] = execute_query(q)
+    end
+  end
+
+  describe "stats_by_environment_and_hour/1" do
+    test "groups by environment and hour and sums" do
+      insert_accuracy("prod", 10, 101, 99)
+      insert_accuracy("prod", 10, 108, 102)
+      insert_accuracy("prod", 11, 225, 211)
+      insert_accuracy("prod", 11, 270, 261)
+      insert_accuracy("dev-green", 10, 401, 399)
+      insert_accuracy("dev-green", 10, 408, 302)
+      insert_accuracy("dev-green", 11, 525, 411)
+      insert_accuracy("dev-green", 11, 570, 461)
+
+      stats =
+        from(acc in PredictionAccuracy, [])
+        |> PredictionAccuracy.stats_by_environment_and_hour()
+        |> Repo.all()
+
+      assert stats == [
+        [10, 209, 201, 809, 701],
+        [11, 495, 472, 1095, 872]
+      ]
+    end
+
+    defp insert_accuracy(env, hour, total, accurate) do
+      PredictionAnalyzer.Repo.insert!(
+        %{@prediction_accuracy |
+          environment: env,
+          hour_of_day: hour,
+          num_predictions: total,
+          num_accurate_predictions: accurate,
+        }
+      )
     end
   end
 

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -44,21 +44,24 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
     conn = get(conn, "/accuracy")
     response = html_response(conn, 200)
 
-    assert response =~ "209" # 101 + 108
-    assert response =~ "96.17%" # (99 + 102) / (101 + 108)
+    # 101 + 108
+    assert response =~ "209"
+    # (99 + 102) / (101 + 108)
+    assert response =~ "96.17%"
 
-    assert response =~ "1095" # 525 + 570
-    assert response =~ "79.63%" # (411 + 461) / (525 + 570)
+    # 525 + 570
+    assert response =~ "1095"
+    # (411 + 461) / (525 + 570)
+    assert response =~ "79.63%"
   end
 
   def insert_accuracy(env, hour, total, accurate) do
-    PredictionAnalyzer.Repo.insert!(
-      %{@prediction_accuracy |
-        environment: env,
+    PredictionAnalyzer.Repo.insert!(%{
+      @prediction_accuracy
+      | environment: env,
         hour_of_day: hour,
         num_predictions: total,
-        num_accurate_predictions: accurate,
-      }
-    )
+        num_accurate_predictions: accurate
+    })
   end
 end

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -5,6 +5,7 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
   @today DateTime.to_date(Timex.local())
 
   @prediction_accuracy %PredictionAccuracy{
+    environment: "prod",
     service_date: @today,
     hour_of_day: 11,
     stop_id: "70120",
@@ -14,20 +15,6 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
     num_predictions: 40,
     num_accurate_predictions: 21
   }
-
-  test "GET /", %{conn: conn} do
-    PredictionAnalyzer.Repo.insert!(@prediction_accuracy)
-
-    conn = get(conn, "/accuracy")
-    response = html_response(conn, 200)
-
-    assert response =~ "70120"
-    assert response =~ "Green-B"
-    assert response =~ "departure"
-    assert response =~ "0-3 min"
-    assert response =~ "40"
-    assert response =~ "21"
-  end
 
   test "GET /accuracy returns a top-level summary of accuracy", %{conn: conn} do
     a1 = %{@prediction_accuracy | num_accurate_predictions: 100, num_predictions: 100}
@@ -44,23 +31,34 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
     assert response =~ "75.0"
   end
 
-  test "GET /accuracy with query params filter prediction accuracy statistics", %{conn: conn} do
-    a1 = %{@prediction_accuracy | num_accurate_predictions: 10, num_predictions: 20}
-
-    a2 = %{
-      @prediction_accuracy
-      | num_accurate_predictions: 20,
-        num_predictions: 20,
-        stop_id: "70121"
-    }
-
-    PredictionAnalyzer.Repo.insert!(a1)
-    PredictionAnalyzer.Repo.insert!(a2)
+  test "GET /accuracy aggregates the results by hour", %{conn: conn} do
+    insert_accuracy("prod", 10, 101, 99)
+    insert_accuracy("prod", 10, 108, 102)
+    insert_accuracy("prod", 11, 225, 211)
+    insert_accuracy("prod", 11, 270, 261)
+    insert_accuracy("dev-green", 10, 401, 399)
+    insert_accuracy("dev-green", 10, 408, 302)
+    insert_accuracy("dev-green", 11, 525, 411)
+    insert_accuracy("dev-green", 11, 570, 461)
 
     conn = get(conn, "/accuracy")
-    assert html_response(conn, 200) =~ "From 30 accurate out of 40 total predictions"
+    response = html_response(conn, 200)
 
-    conn = get(conn, "/accuracy", %{"filters" => %{"stop_id" => "70120"}})
-    assert html_response(conn, 200) =~ "From 10 accurate out of 20 total predictions"
+    assert response =~ "209" # 101 + 108
+    assert response =~ "96.17%" # (99 + 102) / (101 + 108)
+
+    assert response =~ "1095" # 525 + 570
+    assert response =~ "79.63%" # (411 + 461) / (525 + 570)
+  end
+
+  def insert_accuracy(env, hour, total, accurate) do
+    PredictionAnalyzer.Repo.insert!(
+      %{@prediction_accuracy |
+        environment: env,
+        hour_of_day: hour,
+        num_predictions: total,
+        num_accurate_predictions: accurate,
+      }
+    )
   end
 end


### PR DESCRIPTION
Asana: [[2] We can view our prediction accuracy in a table by hour](https://app.asana.com/0/584764604969369/881526879952671).

I was running into intermittent testing failures of the "DB.Connection Ownership Error" variety, which I believe came from the various download and aggregation workers running. Since we don't need to start them automatically in the test environment (certain tests _do_ start a GenServer to test it, but they don't need to be part of the application supervision tree), the first commit here, conditionally starts them in dev and prod.

The main ticket work is in the second commit, which updates the `/accuracy` page to have a table of results by hour, with the prod and dev-green statistics. (It seems to work, but we don't have the functionality to calculate the dev green accuracy yet, so it's just zeroes in my screenshot).

![screen shot 2018-11-02 at 10 48 18 am](https://user-images.githubusercontent.com/384428/47925752-eabf6680-de8c-11e8-83a4-fd8409f6dae3.png)


