### PR TITLE
Add Pruner process to delete old data

### DIFF
--- a/lib/prediction_analyzer/application.ex
+++ b/lib/prediction_analyzer/application.ex
@@ -35,7 +35,8 @@ defmodule PredictionAnalyzer.Application do
           worker(PredictionAnalyzer.Predictions.Download, [
             [name: PredictionAnalyzer.Predictions.Download]
           ]),
-          worker(PredictionAnalyzer.PredictionAccuracy.Aggregator, [])
+          worker(PredictionAnalyzer.PredictionAccuracy.Aggregator, []),
+          worker(PredictionAnalyzer.Pruner, [])
         ]
       else
         []

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -22,7 +22,11 @@ defmodule PredictionAnalyzer.Pruner do
   def handle_info(:prune, state) do
     Logger.info("Beginning prune of DB")
 
-    unix_cutoff = Timex.local() |> Timex.shift(days: -7) |> DateTime.to_unix()
+    unix_cutoff =
+      Timex.local()
+      |> Timex.shift(days: -7)
+      |> Timex.set(hour: 3, minute: 0, second: 0)
+      |> DateTime.to_unix()
 
     {time, _} =
       :timer.tc(fn ->

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -1,0 +1,48 @@
+defmodule PredictionAnalyzer.Pruner do
+  use GenServer
+
+  alias PredictionAnalyzer.Utilities
+  alias PredictionAnalyzer.Repo
+  alias PredictionAnalyzer.VehicleEvents.VehicleEvent
+  alias PredictionAnalyzer.Predictions.Prediction
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init([]) do
+    schedule_next_run(self())
+    {:ok, []}
+  end
+
+  def handle_info(:prune, state) do
+    Logger.info("Beginning prune of DB")
+
+    unix_cutoff = Timex.local() |> Timex.shift(days: -7) |> DateTime.to_unix()
+
+    Repo.delete_all(
+      from(
+        p in Prediction,
+        where: p.file_timestamp < ^unix_cutoff
+      )
+    )
+
+    Repo.delete_all(
+      from(
+        ve in VehicleEvent,
+        where: ve.arrival_time < ^unix_cutoff or ve.departure_time < ^unix_cutoff
+      )
+    )
+
+    schedule_next_run(self())
+    {:noreply, state}
+  end
+
+  defp schedule_next_run(pid) do
+    Process.send_after(pid, :prune, Utilities.ms_to_3am(Timex.local()))
+  end
+end

--- a/lib/prediction_analyzer/utilities.ex
+++ b/lib/prediction_analyzer/utilities.ex
@@ -35,4 +35,20 @@ defmodule PredictionAnalyzer.Utilities do
     |> Timex.set(minute: 0, second: 30)
     |> Timex.diff(local_now, :milliseconds)
   end
+
+  @doc """
+  Returns the number of ms to the next 3am local time.
+  """
+  def ms_to_3am(local_now) do
+    run_day =
+      if local_now.hour < 3 do
+        local_now
+      else
+        Timex.shift(local_now, days: 1)
+      end
+
+    run_day
+    |> Timex.set(hour: 3, minute: 0, second: 0, microsecond: {0, 6})
+    |> Timex.diff(local_now, :milliseconds)
+  end
 end

--- a/test/prediction_analyzer/pruner_test.exs
+++ b/test/prediction_analyzer/pruner_test.exs
@@ -1,0 +1,69 @@
+defmodule PredictionAnalyzer.PrunerTest do
+  use ExUnit.Case, async: false
+
+  alias PredictionAnalyzer.Pruner
+  alias PredictionAnalyzer.VehicleEvents.VehicleEvent
+  alias PredictionAnalyzer.Predictions.Prediction
+  alias PredictionAnalyzer.Repo
+
+  import Ecto.Query, only: [from: 2]
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(PredictionAnalyzer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(PredictionAnalyzer.Repo, {:shared, self()})
+  end
+
+  @prediction %Prediction{
+    file_timestamp: :os.system_time(:second),
+    trip_id: "trip",
+    is_deleted: false,
+    delay: 0,
+    arrival_time: nil,
+    boarding_status: nil,
+    departure_time: nil,
+    schedule_relationship: "SCHEDULED",
+    stop_id: "stop",
+    route_id: "route",
+    stop_sequence: 10,
+    stops_away: 2,
+    vehicle_event_id: nil
+  }
+
+  @vehicle_event %VehicleEvent{
+    vehicle_id: "vehicle",
+    vehicle_label: "label",
+    is_deleted: false,
+    route_id: "route",
+    direction_id: 0,
+    trip_id: "trip",
+    stop_id: "stop",
+    arrival_time: nil,
+    departure_time: nil
+  }
+
+  test "starts up with no issue" do
+    {:ok, pid} = Pruner.start_link()
+    :timer.sleep(500)
+    assert Process.alive?(pid)
+  end
+
+  test "prune deletes old data and leaves new data alone" do
+    days_ago_8 = Timex.local() |> Timex.shift(days: -8) |> DateTime.to_unix()
+    days_ago_5 = Timex.local() |> Timex.shift(days: -5) |> DateTime.to_unix()
+
+    %{id: ve1} = Repo.insert!(%{@vehicle_event | arrival_time: days_ago_8})
+    %{id: ve2} = Repo.insert!(%{@vehicle_event | arrival_time: days_ago_5})
+    %{id: _ve3} = Repo.insert!(%{@vehicle_event | arrival_time: days_ago_8})
+    %{id: _p1} = Repo.insert!(%{@prediction | file_timestamp: days_ago_8, vehicle_event_id: ve1})
+    %{id: _p2} = Repo.insert!(%{@prediction | file_timestamp: days_ago_8})
+    %{id: p3} = Repo.insert!(%{@prediction | file_timestamp: days_ago_5})
+
+    assert Repo.one(from(ve in VehicleEvent, select: fragment("count(*)"))) == 3
+    assert Repo.one(from(p in Prediction, select: fragment("count(*)"))) == 3
+
+    {:noreply, []} = Pruner.handle_info(:prune, [])
+
+    assert [%{id: ^ve2}] = Repo.all(from(ve in VehicleEvent, select: ve))
+    assert [%{id: ^p3}] = Repo.all(from(p in Prediction, select: p))
+  end
+end

--- a/test/prediction_analyzer/utilities_test.exs
+++ b/test/prediction_analyzer/utilities_test.exs
@@ -35,4 +35,24 @@ defmodule PredictionAnalyzer.UtilitiesTest do
       assert Utilities.ms_to_next_hour(late) == 3_510_000
     end
   end
+
+  describe "ms_to_3am" do
+    test "returns the milliseconds to 3am when 3am is tomorrow" do
+      time =
+        "America/New_York"
+        |> Timex.now()
+        |> Timex.set(hour: 23, minute: 59, second: 0, microsecond: {0, 6})
+
+      assert Utilities.ms_to_3am(time) == 10_860_000
+    end
+
+    test "returns the milliseconds to 3am when 3am is later today" do
+      time =
+        "America/New_York"
+        |> Timex.now()
+        |> Timex.set(hour: 2, minute: 59, second: 0, microsecond: {0, 6})
+
+      assert Utilities.ms_to_3am(time) == 60_000
+    end
+  end
 end

--- a/test/prediction_analyzer/utilities_test.exs
+++ b/test/prediction_analyzer/utilities_test.exs
@@ -4,7 +4,7 @@ defmodule PredictionAnalyzer.UtilitiesTest do
 
   describe "service_date_info" do
     test "returns current date if after 3am" do
-      time = Timex.set(Timex.now("America/New_York"), year: 2018, month: 10, day: 30, hour: 10)
+      time = Timex.to_datetime(~D[2018-10-30], "America/New_York") |> Timex.set(hour: 10)
 
       assert {
                ~D[2018-10-30],
@@ -15,7 +15,7 @@ defmodule PredictionAnalyzer.UtilitiesTest do
     end
 
     test "returns previous date if before 3am" do
-      time = Timex.set(Timex.now("America/New_York"), year: 2018, month: 10, day: 30, hour: 1)
+      time = Timex.to_datetime(~D[2018-10-30], "America/New_York") |> Timex.set(hour: 1)
 
       assert {
                ~D[2018-10-29],


### PR DESCRIPTION
Asana: [(4) New GenServer that runs every day at 3 am and deletes the old data (and maybe manually runs VACUUM?)](https://app.asana.com/0/584764604969369/884753442917093).

I was reading about the VACUUMing online, and I think AUTO VACUUM might be enough for us. We can watch the metrics to see if our space gets unusable but postgres should be vacuuming itself in a concurrent fashion as necessary. So, I opted not to manually trigger one here.