### PR TITLE
Second half of index performance improvements

### DIFF
--- a/lib/prediction_analyzer/application.ex
+++ b/lib/prediction_analyzer/application.ex
@@ -48,11 +48,9 @@ defmodule PredictionAnalyzer.Application do
 
     case Supervisor.start_link(supervisors ++ workers, opts) do
       {:ok, _} = success ->
-        spawn(fn ->
-          Logger.info("Started application, running migrations")
-          Application.get_env(:prediction_analyzer, :migration_task).migrate()
-          Logger.info("Finished migrations")
-        end)
+        Logger.info("Started application, running migrations")
+        Application.get_env(:prediction_analyzer, :migration_task).migrate()
+        Logger.info("Finished migrations")
 
         success
 

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -30,6 +30,8 @@ defmodule PredictionAnalyzer.Pruner do
 
     {time, _} =
       :timer.tc(fn ->
+        Logger.info("deleting old predictions")
+
         Repo.delete_all(
           from(
             p in Prediction,
@@ -37,10 +39,21 @@ defmodule PredictionAnalyzer.Pruner do
           )
         )
 
+        Logger.info("deleting old vehicle events based on arrival")
+
         Repo.delete_all(
           from(
             ve in VehicleEvent,
-            where: ve.arrival_time < ^unix_cutoff or ve.departure_time < ^unix_cutoff
+            where: ve.arrival_time < ^unix_cutoff
+          )
+        )
+
+        Logger.info("deleting old vehicle events based on departure")
+
+        Repo.delete_all(
+          from(
+            ve in VehicleEvent,
+            where: ve.departure_time < ^unix_cutoff
           )
         )
       end)

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -105,7 +105,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
       p in Prediction,
       where:
         p.trip_id == ^vehicle_event.trip_id and p.stop_id == ^vehicle_event.stop_id and
-          p.environment == ^vehicle_event.environment and
+          p.environment == ^vehicle_event.environment and is_nil(p.vehicle_event_id) and
           p.file_timestamp > ^(:os.system_time(:second) - 60 * 60 * 3),
       update: [set: [vehicle_event_id: ^vehicle_event.id]]
     )


### PR DESCRIPTION
This is the second half of #36 . It reverts the necessary evil that was running the migrations in a spawned process, and tweaks the code to use these new indexes.