### PR TITLE
Increase timeout of pruning queries

### DIFF
--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -68,6 +68,6 @@ defmodule PredictionAnalyzer.Pruner do
   end
 
   defp schedule_next_run(pid) do
-    Process.send_after(pid, :prune, Utilities.ms_to_3am(Timex.local()))
+    Process.send_after(pid, :prune, Utilities.ms_to_3am(Timex.local()) + 10 * 60 * 1_000)
   end
 end

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -36,7 +36,8 @@ defmodule PredictionAnalyzer.Pruner do
           from(
             p in Prediction,
             where: p.file_timestamp < ^unix_cutoff
-          )
+          ),
+          timeout: 120_000
         )
 
         Logger.info("deleting old vehicle events based on arrival")
@@ -45,7 +46,8 @@ defmodule PredictionAnalyzer.Pruner do
           from(
             ve in VehicleEvent,
             where: ve.arrival_time < ^unix_cutoff
-          )
+          ),
+          timeout: 120_000
         )
 
         Logger.info("deleting old vehicle events based on departure")
@@ -54,7 +56,8 @@ defmodule PredictionAnalyzer.Pruner do
           from(
             ve in VehicleEvent,
             where: ve.departure_time < ^unix_cutoff
-          )
+          ),
+          timeout: 120_000
         )
       end)
 


### PR DESCRIPTION
The added logging from yesterday's PR helped. The timeout came when deleting the predictions, not the vehicle_events, so those indexes added didn't solve the issue.

Here I'm increasing the timeout of the delete command from 15 seconds to 2 minutes. I'm not totally sure if deleting prevents any updates to the entire table, or just the rows being deleted, but regardless at 3am there shouldn't really be any predictions being inserted anyway.

I also bumped the Pruner to run at 3am + 10 minutes, just so it doesn't run at the same time as the Aggregator which will be running at 3am for data collected from 1am - 2am (which is valid data).