### PR TITLE
Bump delete timeout for vehicle events to 10 mins

### DIFF
--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -47,7 +47,7 @@ defmodule PredictionAnalyzer.Pruner do
             ve in VehicleEvent,
             where: ve.arrival_time < ^unix_cutoff
           ),
-          timeout: 120_000
+          timeout: 600_000
         )
 
         Logger.info("deleting old vehicle events based on departure")
@@ -57,7 +57,7 @@ defmodule PredictionAnalyzer.Pruner do
             ve in VehicleEvent,
             where: ve.departure_time < ^unix_cutoff
           ),
-          timeout: 120_000
+          timeout: 600_000
         )
       end)
 


### PR DESCRIPTION
First time it runs might be extra long since there's a lot of data in there. Going forward, it will only be deleting one day's worth of data so probably shorter.