### PR TITLE
Run concurrent migration to add index for predictions.vehicle_event_id

### DIFF
--- a/lib/prediction_analyzer/application.ex
+++ b/lib/prediction_analyzer/application.ex
@@ -48,9 +48,11 @@ defmodule PredictionAnalyzer.Application do
 
     case Supervisor.start_link(supervisors ++ workers, opts) do
       {:ok, _} = success ->
-        Logger.info("Started application, running migrations")
-        Application.get_env(:prediction_analyzer, :migration_task).migrate()
-        Logger.info("Finished migrations")
+        spawn(fn ->
+          Logger.info("Started application, running migrations")
+          Application.get_env(:prediction_analyzer, :migration_task).migrate()
+          Logger.info("Finished migrations")
+        end)
 
         success
 

--- a/priv/repo/migrations/20181112161231_add_index_to_predictions_vehicle_event_id.exs
+++ b/priv/repo/migrations/20181112161231_add_index_to_predictions_vehicle_event_id.exs
@@ -1,0 +1,8 @@
+defmodule PredictionAnalyzer.Repo.Migrations.AddIndexToPredictionsVehicleEventId do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+  def change do
+    create index("predictions", [:vehicle_event_id], concurrently: true)
+  end
+end


### PR DESCRIPTION
I think I've finally figured out why the pruning was timing out: the call that was timing out was deleting all the old rows of `vehicle_events`. We have a foreign key `predictions.vehicle_event_id`, with "on delete cascade", so for every row that we delete in `vehicle_events` we then delete all the old predictions that point to it. I didn't realize that postgres doesn't automatically index foreign keys! So we were doing table scans of the multi-million row predictions table with every row we delete in the other table.

I create the index concurrently, and also outside of app start up, as in #36 for the reasons specified there:

> Postgres (and Ecto) allows for creating indexes concurrently, that is, without locking the table that's getting the index, but to allow it to happen you have to disable running the migration in a transaction. This isn't ideal, but it's necessary since on my local data it took a minute to create the index on predictions anyway.

> The other issue is that since we run migrations as a callback on starting the app, if it takes too long the app will fail. I got around that by running the migrations in a process spawned by the app on start. This isn't great in general, since we don't get feedback if the migrations fail (other than logs), so I plan to revert this particular change once this code has been deployed.