### PR TITLE
Restore sync start-up, lower pruning timeout

### DIFF
--- a/lib/prediction_analyzer/application.ex
+++ b/lib/prediction_analyzer/application.ex
@@ -48,11 +48,9 @@ defmodule PredictionAnalyzer.Application do
 
     case Supervisor.start_link(supervisors ++ workers, opts) do
       {:ok, _} = success ->
-        spawn(fn ->
-          Logger.info("Started application, running migrations")
-          Application.get_env(:prediction_analyzer, :migration_task).migrate()
-          Logger.info("Finished migrations")
-        end)
+        Logger.info("Started application, running migrations")
+        Application.get_env(:prediction_analyzer, :migration_task).migrate()
+        Logger.info("Finished migrations")
 
         success
 

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -47,7 +47,7 @@ defmodule PredictionAnalyzer.Pruner do
             ve in VehicleEvent,
             where: ve.arrival_time < ^unix_cutoff
           ),
-          timeout: 600_000
+          timeout: 120_000
         )
 
         Logger.info("deleting old vehicle events based on departure")
@@ -57,7 +57,7 @@ defmodule PredictionAnalyzer.Pruner do
             ve in VehicleEvent,
             where: ve.departure_time < ^unix_cutoff
           ),
-          timeout: 600_000
+          timeout: 120_000
         )
       end)
 


### PR DESCRIPTION
Pruning finally ran to completion last night! It was the index on the FK that was necessary. This PR restores a synchronous migration start up, which is what we usually want, and lowers the pruning timeout back to 2 minutes from 10, since it wasn't the super long timeout that was necessary after all. (Last night it took 40 seconds, but will probably be even shorter going forward, now that it's been pruned once).

If we have to do this sync-startup toggle a lot, might be worth changing this to an environment variable. We'll see if we have to do it again.