### PR TITLE
Allow 0-3 bucket to include predictions up to 15 seconds in the past

### DIFF
--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -24,7 +24,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
   @spec bins() :: map()
   def bins do
     %{
-      "0-3 min" => {0, 180, -60, 60},
+      "0-3 min" => {-15, 180, -60, 60},
       "3-6 min" => {180, 360, -90, 120},
       "6-12 min" => {360, 720, -150, 210},
       "12-30 min" => {720, 1800, -240, 360}

--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -24,7 +24,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
   @spec bins() :: map()
   def bins do
     %{
-      "0-3 min" => {-15, 180, -60, 60},
+      "0-3 min" => {-30, 180, -60, 60},
       "3-6 min" => {180, 360, -90, 120},
       "6-12 min" => {360, 720, -150, 210},
       "12-30 min" => {720, 1800, -240, 360}


### PR DESCRIPTION
To fix things like: http://prediction-analyzer.mbtace.com/accuracy?_utf8=%E2%9C%93&filters%5Broute_id%5D=&filters%5Bstop_id%5D=70001&filters%5Barrival_departure%5D=departure&filters%5Bbin%5D=0-3+min&filters%5Bservice_date%5D=2018-11-14

Lightly groomed asana ticket [here](https://app.asana.com/0/881264583703207/911114372878692).