### PR TITLE
Longer timeout on pruning predictions

### DIFF
--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -37,7 +37,7 @@ defmodule PredictionAnalyzer.Pruner do
             p in Prediction,
             where: p.file_timestamp < ^unix_cutoff
           ),
-          timeout: 120_000
+          timeout: 600_000
         )
 
         Logger.info("deleting old vehicle events based on arrival")


### PR DESCRIPTION
I noticed from the logs that we sometimes the prediction pruning times out. I'm bumping the timeout here to make sure it completes for the next several days. Then we can dial it back down once we see what the usual length of time is.