### PR TITLE
use vehicle id instead of trip id in the comparator:

### DIFF
--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -69,6 +69,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
               :dev_green -> "dev-green"
             end,
           trip_id: prediction["trip_update"]["trip"]["trip_id"],
+          vehicle_id: prediction["trip_update"]["vehicle"]["id"],
           route_id: prediction["trip_update"]["trip"]["route_id"],
           is_deleted: prediction["is_deleted"]
         }

--- a/lib/prediction_analyzer/predictions/prediction.ex
+++ b/lib/prediction_analyzer/predictions/prediction.ex
@@ -6,6 +6,7 @@ defmodule PredictionAnalyzer.Predictions.Prediction do
     field(:file_timestamp, :integer)
     field(:environment, :string)
     field(:trip_id, :string)
+    field(:vehicle_id, :string)
     field(:is_deleted, :boolean)
     field(:delay, :integer)
     field(:arrival_time, :integer)
@@ -31,6 +32,7 @@ defmodule PredictionAnalyzer.Predictions.Prediction do
         "stop_sequence,",
         "stops_away,",
         "trip_id,",
+        "vehicle_id,",
         "route_id,",
         "stop_id,",
         "predicted_arrival,",
@@ -58,6 +60,7 @@ defmodule PredictionAnalyzer.Predictions.Prediction do
           p.stop_sequence,
           p.stops_away,
           p.trip_id,
+          p.vehicle_id,
           p.route_id,
           p.stop_id,
           p.arrival_time,

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -104,7 +104,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     from(
       p in Prediction,
       where:
-        p.trip_id == ^vehicle_event.trip_id and p.stop_id == ^vehicle_event.stop_id and
+        p.vehicle_id == ^vehicle_event.vehicle_id and p.stop_id == ^vehicle_event.stop_id and
           p.environment == ^vehicle_event.environment and is_nil(p.vehicle_event_id) and
           p.file_timestamp > ^(:os.system_time(:second) - 60 * 60 * 3),
       update: [set: [vehicle_event_id: ^vehicle_event.id]]

--- a/test/prediction_analyzer/predictions/prediction_test.exs
+++ b/test/prediction_analyzer/predictions/prediction_test.exs
@@ -28,9 +28,9 @@ defmodule PredictionAnalyzer.Predictions.PredictionTest do
         |> String.split()
 
       assert lines == [
-               "env,file_timestamp,is_deleted,delay,boarding_status,schedule_relationship,stop_sequence,stops_away,trip_id,route_id,stop_id,predicted_arrival,predicted_departure,vehicle_id,vehicle_label,vehicle_direction_id,actual_arrival,actual_departure",
-               "prod,123,,,,,,,trip1,route1,stop1,234,,,,,,",
-               ",,,,,,,,,,,,,vehicle1,,,,"
+               "env,file_timestamp,is_deleted,delay,boarding_status,schedule_relationship,stop_sequence,stops_away,trip_id,vehicle_id,route_id,stop_id,predicted_arrival,predicted_departure,vehicle_id,vehicle_label,vehicle_direction_id,actual_arrival,actual_departure",
+               "prod,123,,,,,,,trip1,,route1,stop1,234,,,,,,",
+               ",,,,,,,,,,,,,,vehicle1,,,,"
              ]
     end
   end

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -87,6 +87,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
       prediction1 = %{
         @prediction
         | trip_id: "trip1",
+          vehicle_id: "1",
           arrival_time: :os.system_time(:second),
           stop_id: "stop1"
       }
@@ -94,6 +95,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
       prediction2 = %{
         @prediction
         | trip_id: "trip1",
+          vehicle_id: "1",
           arrival_time: :os.system_time(:second),
           stop_id: "stop0"
       }
@@ -101,6 +103,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
       prediction3 = %{
         @prediction
         | trip_id: "trip1",
+          vehicle_id: "1",
           arrival_time: :os.system_time(:second) - 24 * 60 * 60,
           file_timestamp: :os.system_time(:second) - 60 * 60 * 24,
           stop_id: "stop1"


### PR DESCRIPTION
[(2) Update TripUpdates DL logic to save vehicle_id. Update Comparator to use vehicle_id rather than trip_id. Also consider when vehicle departs station.](https://app.asana.com/0/584764604969369/929449096386420)