### PR TITLE
Limit lookback to 30 minutes

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -100,6 +100,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     }
   end
 
+  @spec associate_vehicle_event_with_predictions(VehicleEvent.t()) :: nil
   defp associate_vehicle_event_with_predictions(vehicle_event) do
     from(
       p in Prediction,
@@ -117,5 +118,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
       {n, _} ->
         Logger.info("Associated vehicle_event with #{n} prediction(s)")
     end
+
+    nil
   end
 end

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -106,7 +106,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
       where:
         p.vehicle_id == ^vehicle_event.vehicle_id and p.stop_id == ^vehicle_event.stop_id and
           p.environment == ^vehicle_event.environment and is_nil(p.vehicle_event_id) and
-          p.file_timestamp > ^(:os.system_time(:second) - 60 * 60 * 3),
+          p.file_timestamp > ^(:os.system_time(:second) - 60 * 30),
       update: [set: [vehicle_event_id: ^vehicle_event.id]]
     )
     |> Repo.update_all([])

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -96,21 +96,29 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
         @prediction
         | trip_id: "trip1",
           vehicle_id: "1",
-          arrival_time: :os.system_time(:second),
-          stop_id: "stop0"
+          arrival_time: :os.system_time(:second) - 60 * 15,
+          stop_id: "stop1"
       }
 
       prediction3 = %{
         @prediction
         | trip_id: "trip1",
           vehicle_id: "1",
-          arrival_time: :os.system_time(:second) - 24 * 60 * 60,
-          file_timestamp: :os.system_time(:second) - 60 * 60 * 24,
+          arrival_time: :os.system_time(:second),
+          stop_id: "stop0"
+      }
+
+      prediction4 = %{
+        @prediction
+        | trip_id: "trip1",
+          vehicle_id: "1",
+          arrival_time: :os.system_time(:second) - 60 * 60,
+          file_timestamp: :os.system_time(:second) - 60 * 60,
           stop_id: "stop1"
       }
 
-      [p1_id, p2_id, p3_id] =
-        Enum.map([prediction1, prediction2, prediction3], fn prediction ->
+      [p1_id, p2_id, p3_id, p4_id] =
+        Enum.map([prediction1, prediction2, prediction3, prediction4], fn prediction ->
           Repo.insert!(prediction) |> Map.get(:id)
         end)
 
@@ -132,9 +140,12 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
                ve_id
 
       assert Repo.one(from(p in Prediction, where: p.id == ^p2_id, select: p.vehicle_event_id)) ==
-               nil
+               ve_id
 
       assert Repo.one(from(p in Prediction, where: p.id == ^p3_id, select: p.vehicle_event_id)) ==
+               nil
+
+      assert Repo.one(from(p in Prediction, where: p.id == ^p4_id, select: p.vehicle_event_id)) ==
                nil
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Improve prediction analyzer predictions/vehicle_events matching by limiting look-back to 30 minutes](https://app.asana.com/0/584764604969369/935149940976869/f)

Updated the comparator itself. Updated tests to make sure predictions in the past are linked to provided that they're not before the lookback period.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
