### PR TITLE
Add health check endpoint

### DIFF
--- a/lib/prediction_analyzer_web/controllers/health_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/health_controller.ex
@@ -1,6 +1,7 @@
 defmodule PredictionAnalyzerWeb.HealthController do
   use PredictionAnalyzerWeb, :controller
 
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     conn
     |> send_resp(200, "Healthy")

--- a/lib/prediction_analyzer_web/controllers/health_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/health_controller.ex
@@ -1,0 +1,9 @@
+defmodule PredictionAnalyzerWeb.HealthController do
+  use PredictionAnalyzerWeb, :controller
+
+  def index(conn, _params) do
+    conn
+    |> send_resp(200, "Healthy")
+    |> halt()
+  end
+end

--- a/lib/prediction_analyzer_web/router.ex
+++ b/lib/prediction_analyzer_web/router.ex
@@ -21,6 +21,7 @@ defmodule PredictionAnalyzerWeb.Router do
     get("/predictions", PredictionsController, :index)
     get("/vehicle_events", VehicleEventsController, :index)
     get("/accuracy", AccuracyController, :index)
+    get("/_health", HealthController, :index)
   end
 
   # Other scopes may use custom stacks.

--- a/test/prediction_analyzer_web/controllers/health_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/health_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule PredictionAnalyzerWeb.HealthControllerTest do
+  use PredictionAnalyzerWeb.ConnCase
+
+  test "GET /_health", %{conn: conn} do
+    conn = get(conn, "/_health")
+    assert response(conn, 200) == "Healthy"
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** none

Our deploy failed because we were using /accuracy as the AWS health check endpoint, but we changed it to redirect. This is a much lighter weight endpoint anyway, and one we likely won't change inadvertently.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
