### PR TITLE
migration for not nil vehicle id

### DIFF
--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -23,6 +23,9 @@ defmodule FakeHTTPoison do
           "is_deleted" => false,
           "trip_update" => %{
             "delay" => nil,
+            "vehicle" => %{
+              "id" => "vehicle_id"
+            },
             "trip" => %{
               "trip_id" => "TEST_TRIP",
               "route_id" => "Blue"

--- a/priv/repo/migrations/20190114210649_vehicle_id_not_nil.exs
+++ b/priv/repo/migrations/20190114210649_vehicle_id_not_nil.exs
@@ -1,0 +1,15 @@
+defmodule PredictionAnalyzer.Repo.Migrations.VehicleIdNotNil do
+  use Ecto.Migration
+
+  def change do
+    alter table("predictions") do
+      modify(:vehicle_id, :string, null: false)
+    end
+  end
+
+  def down do
+    alter table("predictions") do
+      modify(:vehicle_id, :string, null: true)
+    end
+  end
+end

--- a/test/prediction_analyzer/prediction_accuracy/query_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/query_test.exs
@@ -13,6 +13,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
 
   @prediction %Prediction{
     file_timestamp: :os.system_time(:second),
+    vehicle_id: "vehicle",
     environment: "dev-green",
     trip_id: "trip",
     is_deleted: false,

--- a/test/prediction_analyzer/pruner_test.exs
+++ b/test/prediction_analyzer/pruner_test.exs
@@ -15,6 +15,7 @@ defmodule PredictionAnalyzer.PrunerTest do
 
   @prediction %Prediction{
     file_timestamp: :os.system_time(:second),
+    vehicle_id: "vehicle",
     trip_id: "trip",
     is_deleted: false,
     delay: 0,

--- a/test/prediction_analyzer_web/controllers/predictions_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/predictions_controller_test.exs
@@ -18,6 +18,7 @@ defmodule PredictionAnalyzerWeb.PredictionsControllerTest do
 
     prediction = %PredictionAnalyzer.Predictions.Prediction{
       file_timestamp: 1_542_558_122,
+      vehicle_id: "v1",
       trip_id: "TEST_TRIP",
       is_deleted: false,
       delay: 0,
@@ -70,6 +71,7 @@ defmodule PredictionAnalyzerWeb.PredictionsControllerTest do
     {:ok, %{id: vehicle_event_id}} = PredictionAnalyzer.Repo.insert(vehicle_event)
 
     prediction = %PredictionAnalyzer.Predictions.Prediction{
+      vehicle_id: "v1",
       file_timestamp: 1_542_608_520,
       trip_id: "TEST_TRIP",
       is_deleted: false,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Make predictions.vehicle_id NOT NULL after 7 days](https://app.asana.com/0/881264583703207/923338667921775)

here it is, vehicles are supposed to be required now.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
