### PR TITLE
Specify arbitrary dates for Hourly chart and date range for Daily

### DIFF
--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -50,6 +50,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
     |> validate_inclusion(:bin, Map.keys(bins()))
   end
 
+  @spec filter(map()) :: {Ecto.Query.t(), nil | String.t()}
   def filter(params) do
     q = from(acc in __MODULE__, [])
 
@@ -71,24 +72,29 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
     end
   end
 
+  @spec filter_by_route(Ecto.Query.t(), any()) :: {:ok, Ecto.Query.t()} | {:error, String.t()}
   defp filter_by_route(q, route_id) when is_binary(route_id) and route_id != "" do
     {:ok, from(acc in q, where: acc.route_id == ^route_id)}
   end
 
   defp filter_by_route(q, _), do: {:ok, q}
 
+  @spec filter_by_stop(Ecto.Query.t(), any()) :: {:ok, Ecto.Query.t()} | {:error, String.t()}
   defp filter_by_stop(q, stop_id) when is_binary(stop_id) and stop_id != "" do
     {:ok, from(acc in q, where: acc.stop_id == ^stop_id)}
   end
 
   defp filter_by_stop(q, _), do: {:ok, q}
 
+  @spec filter_by_arrival_departure(Ecto.Query.t(), any()) ::
+          {:ok, Ecto.Query.t()} | {:error, String.t()}
   defp filter_by_arrival_departure(q, arr_dep) when arr_dep in ["arrival", "departure"] do
     {:ok, from(acc in q, where: acc.arrival_departure == ^arr_dep)}
   end
 
   defp filter_by_arrival_departure(q, _), do: {:ok, q}
 
+  @spec filter_by_bin(Ecto.Query.t(), any()) :: {:ok, Ecto.Query.t()} | {:error, String.t()}
   defp filter_by_bin(q, bin) do
     if Map.has_key?(bins(), bin) do
       {:ok, from(acc in q, where: acc.bin == ^bin)}
@@ -97,6 +103,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
     end
   end
 
+  @spec filter_by_timeframe(Ecto.Query.t(), any(), any(), any(), any()) ::
+          {:ok, Ecto.Query.t()} | {:error, String.t()}
   defp filter_by_timeframe(q, "Daily", _date, start_date, end_date)
        when is_binary(start_date) and is_binary(end_date) do
     case {Date.from_iso8601(start_date), Date.from_iso8601(end_date)} do

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -63,6 +63,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
     redirect_with_default_filters(conn, params)
   end
 
+  @spec redirect_with_default_filters(Plug.Conn.t(), map()) :: Plug.Conn.t()
   defp redirect_with_default_filters(conn, params) do
     filters = params["filters"] || %{}
 
@@ -124,6 +125,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
     |> Map.put(:chart_type, filter_params["chart_range"] || "Hourly")
   end
 
+  @spec time_filters_present?(map()) :: boolean()
   defp time_filters_present?(filters) do
     (filters["chart_range"] == "Hourly" && filters["service_date"]) ||
       (filters["chart_range"] == "Daily" && filters["daily_date_start"] &&

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -78,16 +78,19 @@
         <%= if f.params["chart_range"] == "Hourly" do %>
           <div class="form-group">
             <%= label(f, :service_date, "Service Date") %>
+            <small>(YYYY-MM-DD)</small>
             <%= text_input(f, :service_date, class: "form-control") %>
           </div>
         <% else %>
           <div class="form-group">
             <%= label(f, :service_date, "Start Date") %>
+            <small>(YYYY-MM-DD)</small>
             <%= text_input(f, :daily_date_start, class: "form-control") %>
           </div>
 
           <div class="form-group">
             <%= label(f, :service_date, "End Date") %>
+            <small>(YYYY-MM-DD)</small>
             <%= text_input(f, :daily_date_end, class: "form-control") %>
           </div>
         <% end %>

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -45,6 +45,12 @@
   <div class="row">
     <div class="col-xs-3">
       <div class="accuracy-form-filters">
+        <%= if @error_msg do %>
+          <div class="alert alert-danger">
+            <%= @error_msg %>
+          </div>
+        <% end %>
+
         <div class="form-group">
           <%= label(f, :stop_id, "Stop ID") %>
           <%= text_input(f, :stop_id, class: "form-control") %>
@@ -72,10 +78,18 @@
         <%= if f.params["chart_range"] == "Hourly" do %>
           <div class="form-group">
             <%= label(f, :service_date, "Service Date") %>
-            <%= select(f, :service_date, service_dates(), class: "form-control") %>
+            <%= text_input(f, :service_date, class: "form-control") %>
           </div>
         <% else %>
-          Range: Last two weeks
+          <div class="form-group">
+            <%= label(f, :service_date, "Start Date") %>
+            <%= text_input(f, :daily_date_start, class: "form-control") %>
+          </div>
+
+          <div class="form-group">
+            <%= label(f, :service_date, "End Date") %>
+            <%= text_input(f, :daily_date_end, class: "form-control") %>
+          </div>
         <% end %>
 
         <div class="form-group">

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -57,7 +57,13 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
           id
         end)
 
-      q = from(acc in PredictionAccuracy.filter(%{}), [])
+      {accs, _} =
+        PredictionAccuracy.filter(%{
+          "chart_range" => "Hourly",
+          "service_date" => Timex.local() |> DateTime.to_date()
+        })
+
+      q = from(acc in accs, [])
 
       assert [%{id: ^acc2_id}, %{id: ^acc3_id}, %{id: ^acc4_id}, %{id: ^acc5_id}] =
                execute_query(q)
@@ -91,22 +97,28 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
           id
         end)
 
-      q =
-        from(acc in PredictionAccuracy.filter(%{"service_date" => Date.to_string(yesterday)}), [])
+      {accs, _} =
+        PredictionAccuracy.filter(%{
+          "chart_range" => "Hourly",
+          "service_date" => Date.to_string(yesterday)
+        })
+
+      q = from(acc in accs, [])
 
       assert [%{id: ^acc1_id}] = execute_query(q)
 
-      q =
-        from(
-          acc in PredictionAccuracy.filter(%{"service_date" => Date.to_string(day_before)}),
-          []
-        )
+      {accs, _} =
+        PredictionAccuracy.filter(%{
+          "chart_range" => "Hourly",
+          "service_date" => Date.to_string(day_before)
+        })
+
+      q = from(acc in accs, [])
 
       assert [%{id: ^acc2_id}] = execute_query(q)
 
-      q = from(acc in PredictionAccuracy.filter(%{"chart_range" => "Daily"}), [])
-
-      assert [%{id: ^acc1_id}, %{id: ^acc2_id}] = execute_query(q)
+      assert {_, "No start or end date given."} =
+               PredictionAccuracy.filter(%{"chart_range" => "Daily"})
     end
   end
 

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -51,36 +51,47 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
       acc4 = %{@prediction_accuracy | arrival_departure: "departure"}
       acc5 = %{@prediction_accuracy | bin: "6-12 min"}
 
+      base_params = %{
+        "chart_range" => "Hourly",
+        "service_date" => Timex.local() |> Date.to_string()
+      }
+
       [acc1_id, acc2_id, acc3_id, acc4_id, acc5_id] =
         Enum.map([acc1, acc2, acc3, acc4, acc5], fn acc ->
           %{id: id} = Repo.insert!(acc)
           id
         end)
 
-      {accs, _} =
-        PredictionAccuracy.filter(%{
-          "chart_range" => "Hourly",
-          "service_date" => Timex.local() |> DateTime.to_date()
-        })
-
+      {accs, nil} = PredictionAccuracy.filter(base_params)
       q = from(acc in accs, [])
 
       assert [%{id: ^acc2_id}, %{id: ^acc3_id}, %{id: ^acc4_id}, %{id: ^acc5_id}] =
                execute_query(q)
 
-      q = from(acc in PredictionAccuracy.filter(%{"service_date" => "2018-01-01"}), [])
+      {accs, nil} =
+        PredictionAccuracy.filter(Map.merge(base_params, %{"service_date" => "2018-01-01"}))
+
+      q = from(acc in accs, [])
       assert [%{id: ^acc1_id}] = execute_query(q)
 
-      q = from(acc in PredictionAccuracy.filter(%{"stop_id" => "some_stop"}), [])
+      {accs, nil} = PredictionAccuracy.filter(Map.merge(base_params, %{"stop_id" => "some_stop"}))
+      q = from(acc in accs, [])
       assert [%{id: ^acc2_id}] = execute_query(q)
 
-      q = from(acc in PredictionAccuracy.filter(%{"route_id" => "some_route"}), [])
+      {accs, nil} =
+        PredictionAccuracy.filter(Map.merge(base_params, %{"route_id" => "some_route"}))
+
+      q = from(acc in accs, [])
       assert [%{id: ^acc3_id}] = execute_query(q)
 
-      q = from(acc in PredictionAccuracy.filter(%{"arrival_departure" => "departure"}), [])
+      {accs, nil} =
+        PredictionAccuracy.filter(Map.merge(base_params, %{"arrival_departure" => "departure"}))
+
+      q = from(acc in accs, [])
       assert [%{id: ^acc4_id}] = execute_query(q)
 
-      q = from(acc in PredictionAccuracy.filter(%{"bin" => "6-12 min"}), [])
+      {accs, nil} = PredictionAccuracy.filter(Map.merge(base_params, %{"bin" => "6-12 min"}))
+      q = from(acc in accs, [])
       assert [%{id: ^acc5_id}] = execute_query(q)
     end
 
@@ -97,7 +108,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
           id
         end)
 
-      {accs, _} =
+      {accs, nil} =
         PredictionAccuracy.filter(%{
           "chart_range" => "Hourly",
           "service_date" => Date.to_string(yesterday)
@@ -107,7 +118,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       assert [%{id: ^acc1_id}] = execute_query(q)
 
-      {accs, _} =
+      {accs, nil} =
         PredictionAccuracy.filter(%{
           "chart_range" => "Hourly",
           "service_date" => Date.to_string(day_before)

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -162,7 +162,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
       q = from(acc in accs, [])
       assert [%{id: ^acc1_id}, %{id: ^acc2_id}] = execute_query(q)
 
-      assert {accs, "Dates can't be more than 4 weeks apart"} =
+      assert {_accs, "Dates can't be more than 4 weeks apart"} =
                PredictionAccuracy.filter(%{
                  "chart_range" => "Daily",
                  "daily_date_start" => "2018-01-01",

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -91,6 +91,32 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
     refute response =~ "<th>Hour</th>"
   end
 
+  test "GET /accuracy with partial daily range redirects to full range", %{conn: conn} do
+    conn =
+      get(conn, "/accuracy", %{
+        "filters" => %{"chart_range" => "Daily", "daily_date_start" => "2019-01-01"}
+      })
+
+    assert response(conn, 301)
+    assert redirected_to(conn) =~ "Daily"
+    assert redirected_to(conn) =~ "daily_date_start"
+    assert redirected_to(conn) =~ "daily_date_end"
+  end
+
+  test "GET /accuracy with invalid date renders error", %{conn: conn} do
+    conn =
+      get(conn, "/accuracy", %{
+        "filters" => %{
+          "chart_range" => "Daily",
+          "daily_date_start" => "2019-01-01",
+          "daily_date_end" => "invalid"
+        }
+      })
+
+    response = html_response(conn, 200)
+    assert response =~ "Can't parse start or end date."
+  end
+
   def insert_accuracy(env, hour, total, accurate) do
     PredictionAnalyzer.Repo.insert!(%{
       @prediction_accuracy

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -94,10 +94,17 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
   test "GET /accuracy with partial daily range redirects to full range", %{conn: conn} do
     conn =
       get(conn, "/accuracy", %{
-        "filters" => %{"chart_range" => "Daily", "daily_date_start" => "2019-01-01"}
+        "filters" => %{
+          "chart_range" => "Daily",
+          "daily_date_start" => "2019-01-01",
+          "route_id" => "",
+          "stop_id" => "",
+          "arrival_departure" => "all",
+          "bin" => "All"
+        }
       })
 
-    assert response(conn, 301)
+    assert response(conn, 302)
     assert redirected_to(conn) =~ "Daily"
     assert redirected_to(conn) =~ "daily_date_start"
     assert redirected_to(conn) =~ "daily_date_end"
@@ -109,12 +116,16 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
         "filters" => %{
           "chart_range" => "Daily",
           "daily_date_start" => "2019-01-01",
-          "daily_date_end" => "invalid"
+          "daily_date_end" => "invalid",
+          "route_id" => "",
+          "stop_id" => "",
+          "arrival_departure" => "all",
+          "bin" => "All"
         }
       })
 
     response = html_response(conn, 200)
-    assert response =~ "Can't parse start or end date."
+    assert response =~ "Can&#39;t parse start or end date."
   end
 
   def insert_accuracy(env, hour, total, accurate) do

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -104,10 +104,12 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
         }
       })
 
+    today = Timex.local() |> Date.to_string()
+
     assert response(conn, 302)
     assert redirected_to(conn) =~ "Daily"
-    assert redirected_to(conn) =~ "daily_date_start"
-    assert redirected_to(conn) =~ "daily_date_end"
+    assert redirected_to(conn) =~ "filters[daily_date_start]=2019-01-01"
+    assert redirected_to(conn) =~ "filters[daily_date_end]=#{today}"
   end
 
   test "GET /accuracy maintains service date when redirecting", %{conn: conn} do

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -110,6 +110,36 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
     assert redirected_to(conn) =~ "daily_date_end"
   end
 
+  test "GET /accuracy maintains service date when redirecting", %{conn: conn} do
+    conn =
+      get(conn, "/accuracy", %{
+        "filters" => %{
+          "chart_range" => "Hourly",
+          "daily_date_start" => "2019-01-01"
+        }
+      })
+
+    assert response(conn, 302)
+    assert redirected_to(conn) =~ "Hourly"
+    assert redirected_to(conn) =~ "2019-01-01"
+  end
+
+  test "GET /accuracy maintains daily date range when redirecting", %{conn: conn} do
+    conn =
+      get(conn, "/accuracy", %{
+        "filters" => %{
+          "chart_range" => "Daily",
+          "daily_date_start" => "2019-01-01",
+          "daily_date_end" => "2019-01-05"
+        }
+      })
+
+    assert response(conn, 302)
+    assert redirected_to(conn) =~ "Daily"
+    assert redirected_to(conn) =~ "2019-01-01"
+    assert redirected_to(conn) =~ "2019-01-05"
+  end
+
   test "GET /accuracy with invalid date renders error", %{conn: conn} do
     conn =
       get(conn, "/accuracy", %{

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -115,7 +115,7 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
       get(conn, "/accuracy", %{
         "filters" => %{
           "chart_range" => "Hourly",
-          "daily_date_start" => "2019-01-01"
+          "service_date" => "2019-01-01"
         }
       })
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[3 extra] Prediction analyzer: filter daily view by date](https://app.asana.com/0/584764604969369/990404092148943)

Adds a date filter in the sidebar for the "Daily" view:
<img width="282" alt="screen shot 2019-02-01 at 10 30 47 am" src="https://user-images.githubusercontent.com/384428/52136043-c51d3700-260c-11e9-8d8f-b56d697c0f0b.png">

and changes the "Hourly" service date select to a text input for arbitrary dates:

<img width="253" alt="screen shot 2019-02-01 at 10 33 58 am" src="https://user-images.githubusercontent.com/384428/52136094-e8e07d00-260c-11e9-8852-ae3afd4e57bb.png">

If the date range for "daily" is longer than 4 weeks, or if any entered date can't be parsed, an error message appears in the form:

<img width="274" alt="screen shot 2019-02-01 at 10 31 06 am" src="https://user-images.githubusercontent.com/384428/52136142-06154b80-260d-11e9-95a4-a91a14c3fb02.png">

<img width="275" alt="screen shot 2019-02-01 at 10 31 22 am" src="https://user-images.githubusercontent.com/384428/52136148-0b729600-260d-11e9-8aa5-eccf99c79b6b.png">



#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
