### PR TITLE
Some small robustness tweaks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,7 @@ config :prediction_analyzer, PredictionAnalyzerWeb.Endpoint,
 
 # Configures Elixir's Logger
 config :logger, :console,
+  level: :debug,
   format: "$time $metadata[$level] $message\n",
   metadata: [:user_id]
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,8 +20,7 @@ config :prediction_analyzer, PredictionAnalyzerWeb.Endpoint,
   secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE"),
   server: true
 
-# Do not print debug messages in production
-config :logger, level: :info
+config :logger, level: :debug
 
 config :prediction_analyzer, PredictionAnalyzer.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -58,6 +58,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
     {:noreply, predictions}
   end
 
+  @spec store_predictions(map(), :dev_green | :prod) :: {integer(), nil | [term()]} | no_return()
   defp store_predictions(%{"entity" => entities, "header" => %{"timestamp" => timestamp}}, env) do
     predictions =
       Enum.flat_map(entities, fn prediction ->
@@ -89,7 +90,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
         end
       end)
 
-    PredictionAnalyzer.Repo.insert_all(Prediction, predictions)
+    {_, _} = PredictionAnalyzer.Repo.insert_all(Prediction, predictions)
   end
 
   defp store_predictions(_, _) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[2] Alert when prediction analyzer isn't saving accuracy data](https://app.asana.com/0/584764604969369/1109077272113167)

This pattern matches the expected successful return value of `Repo.insert_all`, with the idea being that if it's not that we want to blow up. That said, the [typespec of that function](https://hexdocs.pm/ecto/2.2.11/Ecto.Repo.html#c:insert_all/3) seems to indicate that it already either succeeds or blows up. Can't hurt, though, I guess.

I also changed the logger level to `:debug` to get more Ecto logging (the queries we make and the time they take). I've been wanting to see if we have any long queries and that sort of thing, but was worried about log volume in the past. But after seeing what some of the other apps log, I think we're safe. There's not that many queries, and the info is pretty valuable.

I also made a splunk alert [here](https://mbta.splunkcloud.com/en-US/app/search/alert?s=%2FservicesNS%2Fnobody%2Fsearch%2Fsaved%2Fsearches%2FPrediction%2520Analyzer%2520Errors).

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
