### PR TITLE
Don't warn when updating vehicle_events on departure

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -120,7 +120,9 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     |> Repo.update_all([])
     |> case do
       {0, _} ->
-        Logger.warn("Created vehicle_event with no associated prediction: #{vehicle_event.id}")
+        unless vehicle_event.departure_time do
+          Logger.warn("Created vehicle_event with no associated prediction: #{vehicle_event.id}")
+        end
 
       {n, _} ->
         Logger.info("Associated vehicle_event with #{n} prediction(s)")


### PR DESCRIPTION
#### Summary of changes

No ticket, just fixing an issue with the previous commit to master that was logging excessive warnings.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
