### PR TITLE
Translate terminal stop IDs

### DIFF
--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -28,7 +28,7 @@ defmodule FakeHTTPoison do
             },
             "trip" => %{
               "trip_id" => "TEST_TRIP",
-              "route_id" => "Blue"
+              "route_id" => "Red"
             },
             "stop_time_update" => [
               %{
@@ -40,7 +40,7 @@ defmodule FakeHTTPoison do
                   "uncertainty" => nil
                 },
                 "schedule_relationship" => "SCHEDULED",
-                "stop_id" => "70206",
+                "stop_id" => "Alewife-01",
                 "stop_sequence" => 20,
                 "stops_away" => 5
               },
@@ -57,7 +57,7 @@ defmodule FakeHTTPoison do
                   "uncertainty" => nil
                 },
                 "schedule_relationship" => "SCHEDULED",
-                "stop_id" => "70204",
+                "stop_id" => "70063",
                 "stop_sequence" => 30,
                 "stops_away" => 6
               }

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -82,7 +82,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
               departure_time: update["departure"]["time"],
               boarding_status: update["boarding_status"],
               schedule_relationship: update["schedule_relationship"],
-              stop_id: update["stop_id"],
+              stop_id: PredictionAnalyzer.Utilities.generic_stop_id(update["stop_id"]),
               stop_sequence: update["stop_sequence"],
               stops_away: update["stops_away"]
             })

--- a/lib/prediction_analyzer/utilities.ex
+++ b/lib/prediction_analyzer/utilities.ex
@@ -51,4 +51,15 @@ defmodule PredictionAnalyzer.Utilities do
     |> Timex.set(hour: 3, minute: 0, second: 0, microsecond: {0, 6})
     |> Timex.diff(local_now, :milliseconds)
   end
+
+  @spec generic_stop_id(String.t()) :: String.t()
+  def generic_stop_id("Alewife-01"), do: "70061"
+  def generic_stop_id("Alewife-02"), do: "70061"
+  def generic_stop_id("Braintree-01"), do: "70105"
+  def generic_stop_id("Braintree-02"), do: "70105"
+  def generic_stop_id("Forest Hills-01"), do: "70001"
+  def generic_stop_id("Forest Hills-02"), do: "70001"
+  def generic_stop_id("Oak Grove-01"), do: "70036"
+  def generic_stop_id("Oak Grove-02"), do: "70036"
+  def generic_stop_id(stop_id), do: stop_id
 end

--- a/lib/prediction_analyzer/vehicle_positions/vehicle.ex
+++ b/lib/prediction_analyzer/vehicle_positions/vehicle.ex
@@ -66,7 +66,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
       route_id: route_id,
       direction_id: direction_id,
       current_status: status_atom(current_status),
-      stop_id: stop_id,
+      stop_id: PredictionAnalyzer.Utilities.generic_stop_id(stop_id),
       timestamp: timestamp
     }
 

--- a/test/prediction_analyzer/predictions/download_test.exs
+++ b/test/prediction_analyzer/predictions/download_test.exs
@@ -13,10 +13,16 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
     test "downloads and stores prod predictions" do
       Download.get_predictions(:prod)
       Download.get_predictions(:dev_green)
-      query = from(p in Prediction, select: p.environment)
+      query = from(p in Prediction, select: [p.environment, p.stop_id])
 
       preds = PredictionAnalyzer.Repo.all(query)
-      assert preds == ["prod", "prod", "dev-green", "dev-green"]
+
+      assert preds == [
+               ["prod", "70061"],
+               ["prod", "70063"],
+               ["dev-green", "70061"],
+               ["dev-green", "70063"]
+             ]
     end
   end
 end

--- a/test/prediction_analyzer/utilities_test.exs
+++ b/test/prediction_analyzer/utilities_test.exs
@@ -55,4 +55,18 @@ defmodule PredictionAnalyzer.UtilitiesTest do
       assert Utilities.ms_to_3am(time) == 60_000
     end
   end
+
+  describe "generic_stop_id/1" do
+    test "maps terminal child stop ID to generic terminal stop ID" do
+      assert Utilities.generic_stop_id("Alewife-01") == "70061"
+    end
+
+    test "maps generic terminal stop ID to itself" do
+      assert Utilities.generic_stop_id("70061") == "70061"
+    end
+
+    test "maps non-terminal stop ID to itself" do
+      assert Utilities.generic_stop_id("70063") == "70063"
+    end
+  end
 end

--- a/test/prediction_analyzer/vehicle_positions/vehicle_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/vehicle_test.exs
@@ -56,6 +56,34 @@ defmodule PredictionAnalyzer.VehiclePositions.VehicleTest do
              } = Vehicle.from_json(@data, "dev-green")
     end
 
+    test "translates to generic terminal stop IDs" do
+      assert {
+               :ok,
+               %Vehicle{
+                 id: "B-5458FB84",
+                 environment: "dev-green",
+                 label: "0758",
+                 is_deleted: false,
+                 trip_id: "38078941",
+                 route_id: "Red",
+                 direction_id: 0,
+                 current_status: :INCOMING_AT,
+                 stop_id: "70061"
+               }
+             } =
+               Vehicle.from_json(
+                 %{
+                   @data
+                   | "vehicle" => %{
+                       @data["vehicle"]
+                       | "stop_id" => "Alewife-01",
+                         "trip" => %{@data["vehicle"]["trip"] | "route_id" => "Red"}
+                     }
+                 },
+                 "dev-green"
+               )
+    end
+
     test "returns :error if JSON can't be made into vehicle" do
       bad_data = Map.put(@data, "vehicle", nil)
       assert :error = Vehicle.from_json(bad_data, "dev-green")


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [analyzer: handle new child stops](https://app.asana.com/0/584764604969369/1112207717058010/f)

Added a new utility function to handle the mapping itself. The stop IDs now get translated when downloading either the predictions or vehicle positions JSON, so all of the data stored in prediction analyzer will be in terms of the more generic ID.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
