### PR TITLE
Fix DTX / Park St actuals

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -21,6 +21,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     new_vehicles
   end
 
+  @spec compare_vehicle(Vehicle.t(), Vehicle.t()) :: nil
   defp compare_vehicle(
          %Vehicle{stop_id: new_stop, current_status: new_status} = vehicle,
          %Vehicle{stop_id: old_stop, current_status: old_status}
@@ -35,6 +36,15 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
        )
        when new_stop != old_stop and old_status == :STOPPED_AT and new_status != :STOPPED_AT do
     record_departure(old_vehicle)
+  end
+
+  defp compare_vehicle(
+         %Vehicle{stop_id: new_stop, current_status: new_status} = new_vehicle,
+         %Vehicle{stop_id: old_stop, current_status: old_status} = old_vehicle
+       )
+       when new_stop != old_stop and old_status == :STOPPED_AT and new_status == :STOPPED_AT do
+    record_departure(%Vehicle{old_vehicle | timestamp: new_vehicle.timestamp})
+    record_arrival(new_vehicle)
   end
 
   defp compare_vehicle(%Vehicle{label: label}, nil) do

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -43,7 +43,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
          %Vehicle{stop_id: old_stop, current_status: old_status} = old_vehicle
        )
        when new_stop != old_stop and old_status == :STOPPED_AT and new_status == :STOPPED_AT do
-    record_departure(%Vehicle{old_vehicle | timestamp: new_vehicle.timestamp})
+    record_departure(old_vehicle)
     record_arrival(new_vehicle)
   end
 

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -175,6 +175,51 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
                ve_id
     end
 
+    test "records arrival and departure of vehicle that doesn't track between stations" do
+      base_time = :os.system_time(:second)
+
+      old_vehicles = %{
+        "1" => %{@vehicle | timestamp: base_time}
+      }
+
+      new_vehicles = %{
+        "1" => %{@vehicle | timestamp: base_time + 30, current_status: :STOPPED_AT}
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      old_vehicles = %{
+        "1" => %{@vehicle | timestamp: base_time + 30, current_status: :STOPPED_AT}
+      }
+
+      new_vehicles = %{
+        "1" => %{
+          @vehicle
+          | timestamp: base_time + 60,
+            stop_id: "stop2",
+            current_status: :STOPPED_AT
+        }
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      stop1_arrival = base_time + 30
+      stop1_departure_stop2_arrival = base_time + 60
+
+      assert [
+               %VehicleEvent{
+                 stop_id: "stop1",
+                 arrival_time: ^stop1_arrival,
+                 departure_time: ^stop1_departure_stop2_arrival
+               },
+               %VehicleEvent{
+                 stop_id: "stop2",
+                 arrival_time: ^stop1_departure_stop2_arrival,
+                 departure_time: nil
+               }
+             ] = Repo.all(from(ve in VehicleEvent, select: ve, order_by: [asc: ve.id]))
+    end
+
     test "Don't log vehicle_event warnings for departures" do
       old_vehicles = %{
         "1" => %{@vehicle | stop_id: "stop1", current_status: :IN_TRANSIT_TO}


### PR DESCRIPTION
Fix DTX / Park St actuals

#### Summary of changes
**Asana Ticket:** [Investigate Bug: Why do Red Line Park Street NB and DTX NB have low accuracy?](https://app.asana.com/0/584764604969369/1110212001889553/f)

We need to add a new case to `compare_vehicles` to handle when a vehicle instantly goes from `:STOPPED_AT` one stop to `:STOPPED_AT` another, because in practice we don't seem to get data about when trains are between DTX and Park Street on the Red Line.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
