### PR TITLE
Handle simultaneous departures / arrivals

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -43,7 +43,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
          %Vehicle{stop_id: old_stop, current_status: old_status} = old_vehicle
        )
        when new_stop != old_stop and old_status == :STOPPED_AT and new_status == :STOPPED_AT do
-    record_departure(old_vehicle)
+    record_departure(%{old_vehicle | timestamp: new_vehicle.timestamp})
     record_arrival(new_vehicle)
   end
 

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -31,11 +31,11 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
   end
 
   defp compare_vehicle(
-         %Vehicle{stop_id: new_stop, current_status: new_status},
+         %Vehicle{stop_id: new_stop, current_status: new_status, timestamp: new_timestamp},
          %Vehicle{stop_id: old_stop, current_status: old_status} = old_vehicle
        )
        when new_stop != old_stop and old_status == :STOPPED_AT and new_status != :STOPPED_AT do
-    record_departure(old_vehicle)
+    record_departure(%{old_vehicle | timestamp: new_timestamp})
   end
 
   defp compare_vehicle(

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -21,6 +21,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     new_vehicles
   end
 
+  @spec compare_vehicle(Vehicle.t(), Vehicle.t()) :: nil
   defp compare_vehicle(
          %Vehicle{stop_id: new_stop, current_status: new_status} = vehicle,
          %Vehicle{stop_id: old_stop, current_status: old_status}
@@ -35,6 +36,15 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
        )
        when new_stop != old_stop and old_status == :STOPPED_AT and new_status != :STOPPED_AT do
     record_departure(old_vehicle)
+  end
+
+  defp compare_vehicle(
+         %Vehicle{stop_id: new_stop, current_status: new_status} = new_vehicle,
+         %Vehicle{stop_id: old_stop, current_status: old_status} = old_vehicle
+       )
+       when new_stop != old_stop and old_status == :STOPPED_AT and new_status == :STOPPED_AT do
+    record_departure(old_vehicle)
+    record_arrival(new_vehicle)
   end
 
   defp compare_vehicle(%Vehicle{label: label}, nil) do

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -175,6 +175,51 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
                ve_id
     end
 
+    test "records arrival and departure of vehicle that doesn't track between stations" do
+      base_time = :os.system_time(:second)
+      stop1_arrival = base_time + 30
+      stop1_departure = base_time + 60
+      stop2_arrival = base_time + 90
+
+      old_vehicles = %{
+        "1" => %{@vehicle | timestamp: base_time}
+      }
+
+      new_vehicles = %{
+        "1" => %{@vehicle | timestamp: stop1_arrival, current_status: :STOPPED_AT}
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      old_vehicles = %{
+        "1" => %{@vehicle | timestamp: stop1_departure, current_status: :STOPPED_AT}
+      }
+
+      new_vehicles = %{
+        "1" => %{
+          @vehicle
+          | timestamp: stop2_arrival,
+            stop_id: "stop2",
+            current_status: :STOPPED_AT
+        }
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      assert [
+               %VehicleEvent{
+                 stop_id: "stop1",
+                 arrival_time: ^stop1_arrival,
+                 departure_time: ^stop1_departure
+               },
+               %VehicleEvent{
+                 stop_id: "stop2",
+                 arrival_time: ^stop2_arrival,
+                 departure_time: nil
+               }
+             ] = Repo.all(from(ve in VehicleEvent, select: ve, order_by: [asc: ve.id]))
+    end
+
     test "Don't log vehicle_event warnings for departures" do
       old_vehicles = %{
         "1" => %{@vehicle | stop_id: "stop1", current_status: :IN_TRANSIT_TO}

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -56,20 +56,27 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
 
       Comparator.compare(new_vehicles, old_vehicles)
 
-      timestamp = @vehicle.timestamp
+      arrival_time = @vehicle.timestamp
 
       vehicle_events = Repo.all(from(ve in VehicleEvent, select: ve))
 
       assert [
-               %VehicleEvent{vehicle_id: "1", arrival_time: ^timestamp, departure_time: nil}
+               %VehicleEvent{vehicle_id: "1", arrival_time: ^arrival_time, departure_time: nil}
              ] = vehicle_events
 
       ve_id = List.first(vehicle_events).id
 
+      departure_time = arrival_time + 30
+
       old_vehicles = new_vehicles
 
       new_vehicles = %{
-        "1" => %{@vehicle | current_status: :IN_TRANSIT_TO, stop_id: "stop2"}
+        "1" => %{
+          @vehicle
+          | current_status: :IN_TRANSIT_TO,
+            stop_id: "stop2",
+            timestamp: departure_time
+        }
       }
 
       Comparator.compare(new_vehicles, old_vehicles)
@@ -78,8 +85,8 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
                %VehicleEvent{
                  id: ^ve_id,
                  vehicle_id: "1",
-                 arrival_time: ^timestamp,
-                 departure_time: ^timestamp
+                 arrival_time: ^arrival_time,
+                 departure_time: ^departure_time
                }
              ] = Repo.all(from(ve in VehicleEvent, select: ve))
     end

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -178,8 +178,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
     test "records arrival and departure of vehicle that doesn't track between stations" do
       base_time = :os.system_time(:second)
       stop1_arrival = base_time + 30
-      stop1_departure = base_time + 60
-      stop2_arrival = base_time + 90
+      stop2_arrival = base_time + 60
 
       old_vehicles = %{
         "1" => %{@vehicle | timestamp: base_time}
@@ -192,7 +191,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
       Comparator.compare(new_vehicles, old_vehicles)
 
       old_vehicles = %{
-        "1" => %{@vehicle | timestamp: stop1_departure, current_status: :STOPPED_AT}
+        "1" => %{@vehicle | timestamp: stop1_arrival, current_status: :STOPPED_AT}
       }
 
       new_vehicles = %{
@@ -210,7 +209,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
                %VehicleEvent{
                  stop_id: "stop1",
                  arrival_time: ^stop1_arrival,
-                 departure_time: ^stop1_departure
+                 departure_time: ^stop2_arrival
                },
                %VehicleEvent{
                  stop_id: "stop2",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate Bug: Why do Red Line Park Street NB and DTX NB have low accuracy?](https://app.asana.com/0/584764604969369/1110212001889553/f)

In practice, we don't get location data for Red Line trains at any point between the platforms at Downtown Crossing and Park Street, meaning that they transition from stopped at DTX to stopped at Park with nothing in between. We need to add a new clause to `compare_vehicle` to handle this case and record arrival / departure times appropriately.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
