### PR TITLE
Sort bin options in proper order

### DIFF
--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -72,7 +72,7 @@
 
         <div class="form-group">
           <%= label(f, :bin, "Bin") %>
-          <%= select(f, :bin, ["All" | Map.keys(PredictionAccuracy.bins())], class: "form-control") %>
+          <%= select(f, :bin, ["All" | bin_options()], class: "form-control") %>
         </div>
 
         <%= if f.params["chart_range"] == "Hourly" do %>

--- a/lib/prediction_analyzer_web/views/accuracy_view.ex
+++ b/lib/prediction_analyzer_web/views/accuracy_view.ex
@@ -11,6 +11,17 @@ defmodule PredictionAnalyzerWeb.AccuracyView do
     0
   end
 
+  @spec bin_options() :: [String.t()]
+  def bin_options() do
+    PredictionAccuracy.bins()
+    |> Map.keys()
+    |> Enum.sort_by(fn key ->
+      String.split(key, "-", parts: 2)
+      |> hd
+      |> String.to_integer()
+    end)
+  end
+
   def service_dates(now \\ Timex.local()) do
     0..7
     |> Enum.map(fn n ->

--- a/test/prediction_analyzer_web/views/accuracy_view_test.exs
+++ b/test/prediction_analyzer_web/views/accuracy_view_test.exs
@@ -3,6 +3,10 @@ defmodule PredictionAnalyzerWeb.AccuracyViewTest do
 
   alias PredictionAnalyzerWeb.AccuracyView
 
+  test "bin_options/0 returns bin names in the proper order" do
+    assert AccuracyView.bin_options() == ["0-3 min", "3-6 min", "6-12 min", "12-30 min"]
+  end
+
   test "service_dates/1" do
     time = Timex.local() |> Timex.set(year: 2018, month: 10, day: 31)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1] Sort bins correctly in prediction analyzer](https://app.asana.com/0/584764604969369/1112192658166930)

Bins were appearing in an arbitrary order in the dropdown for same, make sure they're in the natural order.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
