### PR TITLE
Record arrival for train that materializes STOPPED_AT a terminal

### DIFF
--- a/lib/prediction_analyzer/vehicle_events/vehicle_event.ex
+++ b/lib/prediction_analyzer/vehicle_events/vehicle_event.ex
@@ -29,6 +29,7 @@ defmodule PredictionAnalyzer.VehicleEvents.VehicleEvent do
     field(:departure_time, :integer)
   end
 
+  @spec changeset(Ecto.Schema.t(), %{atom => any}) :: Ecto.Changeset.t()
   def changeset(vehicle_event, params \\ %{}) do
     fields = [
       :vehicle_id,

--- a/lib/prediction_analyzer/vehicle_events/vehicle_event.ex
+++ b/lib/prediction_analyzer/vehicle_events/vehicle_event.ex
@@ -42,8 +42,10 @@ defmodule PredictionAnalyzer.VehicleEvents.VehicleEvent do
       :arrival_time
     ]
 
+    required_fields = fields |> Enum.reject(&(&1 == :arrival_time))
+
     vehicle_event
     |> cast(params, fields)
-    |> validate_required(fields)
+    |> validate_required(required_fields)
   end
 end

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -47,7 +47,11 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     record_arrival(new_vehicle)
   end
 
-  defp compare_vehicle(%Vehicle{label: label}, nil) do
+  defp compare_vehicle(%Vehicle{label: label, current_status: status} = vehicle, nil) do
+    if status == :STOPPED_AT do
+      record_arrival(vehicle)
+    end
+
     Logger.info("Tracking new vehicle #{label}")
   end
 

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -116,7 +116,10 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     |> Repo.insert()
     |> case do
       {:ok, vehicle_event} ->
-        Logger.info("Inserted vehicle event: #{vehicle.label} arrived at #{vehicle.stop_id}")
+        Logger.info(
+          "Inserted vehicle event: #{vehicle.label} materialized stopped at #{vehicle.stop_id}"
+        )
+
         associate_vehicle_event_with_predictions(vehicle_event)
 
       {:error, changeset} ->

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -49,7 +49,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
 
   defp compare_vehicle(%Vehicle{label: label, current_status: status} = vehicle, nil) do
     if status == :STOPPED_AT do
-      record_arrival(vehicle)
+      record_new_stopped_vehicle(vehicle)
     end
 
     Logger.info("Tracking new vehicle #{label}")
@@ -88,7 +88,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
       where:
         ve.environment == ^vehicle.environment and ve.vehicle_id == ^vehicle.id and
           ve.stop_id == ^vehicle.stop_id and is_nil(ve.departure_time) and
-          ve.arrival_time > ^(:os.system_time(:second) - 60 * 30),
+          (ve.arrival_time > ^(:os.system_time(:second) - 60 * 30) or is_nil(ve.arrival_time)),
       update: [set: [departure_time: ^vehicle.timestamp]]
     )
     |> Repo.update_all([], returning: true)
@@ -102,6 +102,25 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
 
       {_, _} ->
         Logger.error("One departure, multiple updates for #{vehicle.label}")
+    end
+
+    nil
+  end
+
+  @spec record_new_stopped_vehicle(Vehicle.t()) :: nil
+  defp record_new_stopped_vehicle(vehicle) do
+    params = vehicle |> vehicle_params()
+
+    %VehicleEvent{}
+    |> VehicleEvent.changeset(params)
+    |> Repo.insert()
+    |> case do
+      {:ok, vehicle_event} ->
+        Logger.info("Inserted vehicle event: #{vehicle.label} arrived at #{vehicle.stop_id}")
+        associate_vehicle_event_with_predictions(vehicle_event)
+
+      {:error, changeset} ->
+        Logger.warn("Could not insert vehicle event: #{inspect(changeset)}")
     end
 
     nil

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -226,6 +226,26 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
              ] = Repo.all(from(ve in VehicleEvent, select: ve, order_by: [asc: ve.id]))
     end
 
+    test "records arrival of vehicle created in STOPPED_AT state" do
+      old_vehicles = %{}
+
+      new_vehicles = %{
+        "1" => %{@vehicle | stop_id: "stop1", current_status: :STOPPED_AT}
+      }
+
+      Comparator.compare(new_vehicles, old_vehicles)
+
+      assert [
+               %VehicleEvent{
+                 vehicle_id: "1",
+                 arrival_time: arrival_time,
+                 departure_time: nil
+               }
+             ] = Repo.all(from(ve in VehicleEvent, select: ve))
+
+      assert is_number(arrival_time)
+    end
+
     test "Don't log vehicle_event warnings for departures" do
       old_vehicles = %{
         "1" => %{@vehicle | stop_id: "stop1", current_status: :IN_TRANSIT_TO}

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -262,6 +262,22 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
       assert is_number(departure_time)
     end
 
+    test "logs warning if fails to record creation of vehicle created in STOPPED_AT state" do
+      old_vehicles = %{}
+
+      new_vehicles = %{
+        "1" => %{@vehicle | stop_id: nil, current_status: :STOPPED_AT}
+      }
+
+      log =
+        capture_log([level: :warn], fn ->
+          Comparator.compare(new_vehicles, old_vehicles)
+        end)
+
+      assert log =~ "Could not insert vehicle event"
+      assert [] = Repo.all(from(ve in VehicleEvent, select: ve))
+    end
+
     test "Don't log vehicle_event warnings for departures" do
       old_vehicles = %{
         "1" => %{@vehicle | stop_id: "stop1", current_status: :IN_TRANSIT_TO}

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -233,17 +233,33 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
         "1" => %{@vehicle | stop_id: "stop1", current_status: :STOPPED_AT}
       }
 
+      newer_vehicles = %{
+        "1" => %{@vehicle | stop_id: "stop2", current_status: :IN_TRANSIT}
+      }
+
       Comparator.compare(new_vehicles, old_vehicles)
 
       assert [
                %VehicleEvent{
+                 id: event_id,
                  vehicle_id: "1",
-                 arrival_time: arrival_time,
+                 arrival_time: nil,
                  departure_time: nil
                }
              ] = Repo.all(from(ve in VehicleEvent, select: ve))
 
-      assert is_number(arrival_time)
+      Comparator.compare(newer_vehicles, new_vehicles)
+
+      assert [
+               %VehicleEvent{
+                 id: ^event_id,
+                 vehicle_id: "1",
+                 arrival_time: nil,
+                 departure_time: departure_time
+               }
+             ] = Repo.all(from(ve in VehicleEvent, select: ve))
+
+      assert is_number(departure_time)
     end
 
     test "Don't log vehicle_event warnings for departures" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[2] analyzer: handle first trip of the day](https://app.asana.com/0/584764604969369/1113885023269820)

There are a great many trains in the early hours that appear to not have their arrival at the terminal tracked, so from prediction analyzer's point of view they seem to just appear at the terminal out of nowhere, with a STOPPED_AT status. This results in their departures not being correctly recorded, and our prediction accuracy suffers.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
