### PR TITLE
Sleep a little before retrying aggregate calculation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,6 +37,8 @@ config :prediction_analyzer, PredictionAnalyzer.Repo,
 
 config :prediction_analyzer, start_workers: true
 
+config :prediction_analyzer, retry_sleep_time: 10_000
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,3 +25,4 @@ config :prediction_analyzer,
 
 config :prediction_analyzer, start_workers: false
 config :prediction_analyzer, :stop_name_fetcher, PredictionAnalyzer.FakeStopNameFetcher
+config :prediction_analyzer, retry_sleep_time: 1

--- a/lib/prediction_analyzer/prediction_accuracy/query.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/query.ex
@@ -92,6 +92,9 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         if retry? do
           Logger.warn(log_msg)
 
+          Application.get_env(:prediction_analyzer, :retry_sleep_time)
+          |> Process.sleep()
+
           do_calculate_aggregate_accuracy(
             repo_module,
             current_time,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[2] Improve Analyzer's error recovery](https://app.asana.com/0/584764604969369/1114315916565854)

Immediately retrying this calculation upon a DB error has not proven to be an effective way to handle the error. Here we see if waiting a few seconds before retrying will give the presumed underlying condition a chance to clear up, and allow the retry to work at least some of the time.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
