### PR TITLE
Sort by-station view by accuracy or ID

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -77,7 +77,7 @@
   font-weight: bold;
 }
 
-.chart-range-link {
+.chart-range-link, .sort-order-link {
   background-color: #022441;
   border-color: #b6d8f5;
   border-radius: 3px;
@@ -87,7 +87,8 @@
   display: inline-block;
   line-height: 2.5;
   text-align: center;
-  width: 7em;
+  min-width: 7em;
+  padding: 3px;
 }
 
 .chart-range-link-active {
@@ -97,5 +98,11 @@
 }
 
 .chart-range-links {
+  display: inline-block;
   margin-bottom: 1em;
+  width: 50%;
+}
+
+.sort-order-link {
+  float: right;
 }

--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -64,12 +64,11 @@ function renderDashboard() {
 
   sortedDataPoints = window.dataPoints.sort(sortFunction);
 
-  for(i = 0; i < sortedDataPoints.length; i++) {
-    var dataPoint = sortedDataPoints[i];
+  sortedDataPoints.forEach(function(dataPoint) {
     sortedProdAccs.push(dataPoint.prodAcc);
     sortedDgAccs.push(dataPoint.dgAcc);
     sortedBucketNames.push(dataPoint.bucket);
-  }
+  });
 
   switch(window.chartType) {
     case "Hourly": {

--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -40,7 +40,6 @@ function renderDashboard() {
   var xAxisText;
   var xAxisType;
   var xAxisRotation;
-  var sortedDataPoints;
   var sortFunction;
   var sortOrderLink;
   var sortOrder;
@@ -62,9 +61,9 @@ function renderDashboard() {
     sortFunction = function(a, b) { return ([a.prodAcc, a.dgAcc] < [b.prodAcc, b.dgAcc]) ? -1 : 1; }
   }
 
-  sortedDataPoints = window.dataPoints.sort(sortFunction);
+  window.dataPoints.sort(sortFunction);
 
-  sortedDataPoints.forEach(function(dataPoint) {
+  window.dataPoints.forEach(function(dataPoint) {
     sortedProdAccs.push(dataPoint.prodAcc);
     sortedDgAccs.push(dataPoint.dgAcc);
     sortedBucketNames.push(dataPoint.bucket);
@@ -90,7 +89,7 @@ function renderDashboard() {
       break;
     }
     case "By Station": {
-      chartHeight = sortedDataPoints.length * 25;
+      chartHeight = window.dataPoints.length * 25;
       dataType = "bar";
       rotateAxes = true;
       xAxisText = "";

--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -30,20 +30,48 @@ export function bindFormLinks(accuracyForm) {
   bindChartRangeLink('link-by_station', 'By Station');
 }
 
-export function setupDashboard() {
-  var rawData = window.dataPredictionAccuracyJSON;
-  var prodAccs = rawData["prod_accs"];
-  var dgAccs = rawData["dg_accs"];
-  var dateRangeData = rawData["buckets"];
-  var chartType = rawData["chart_type"];
+export function renderDashboard() {
+  var sortedProdAccs;
+  var sortedDgAccs;
+  var sortedBucketNames;
   var chartHeight;
   var dataType;
   var rotateAxes;
   var xAxisText;
   var xAxisType;
   var xAxisRotation;
+  var sortedDataPoints;
+  var sortFunction;
+  var sortOrderLink;
+  var sortOrder;
+  var i;
 
-  switch(chartType) {
+  sortedProdAccs = [];
+  sortedDgAccs = [];
+  sortedBucketNames = [];
+
+  if(window.sortOrderLink) {
+    sortOrder = window.sortOrderLink.getAttribute("data-sort-order");
+  } else {
+    sortOrder = "by_id";
+  }
+
+  if(sortOrder == "by_id") {
+    sortFunction = function(a, b) { return (a.id < b.id) ? -1 : 1; }
+  } else {
+    sortFunction = function(a, b) { return ([a.prodAcc, a.dgAcc] < [b.prodAcc, b.dgAcc]) ? -1 : 1; }
+  }
+
+  sortedDataPoints = window.dataPoints.sort(sortFunction);
+
+  for(i = 0; i < sortedDataPoints.length; i++) {
+    var dataPoint = sortedDataPoints[i];
+    sortedProdAccs.push(dataPoint.prodAcc);
+    sortedDgAccs.push(dataPoint.dgAcc);
+    sortedBucketNames.push(dataPoint.bucket);
+  }
+
+  switch(window.chartType) {
     case "Hourly": {
       chartHeight = 540;
       dataType = "line";
@@ -63,7 +91,7 @@ export function setupDashboard() {
       break;
     }
     case "By Station": {
-      chartHeight = prodAccs.length * 25;
+      chartHeight = sortedDataPoints.length * 25;
       dataType = "bar";
       rotateAxes = true;
       xAxisText = "";
@@ -73,9 +101,9 @@ export function setupDashboard() {
     }
   }
 
-  var col_1 = ["Prod"].concat(prodAccs);
-  var col_2 = ["Dev Green"].concat(dgAccs);
-  var x_data = ["x"].concat(dateRangeData);
+  var col_1 = ["Prod"].concat(sortedProdAccs);
+  var col_2 = ["Dev Green"].concat(sortedDgAccs);
+  var x_data = ["x"].concat(sortedBucketNames);
 
   var chart = c3.generate({
     bindto: "#chart-prediction-accuracy",
@@ -134,4 +162,44 @@ export function setupDashboard() {
       position: "inset"
     }
   });
+}
+
+export function setupDashboard() {
+  var rawData = window.dataPredictionAccuracyJSON;
+  var prodAccs = rawData["prod_accs"];
+  var dgAccs = rawData["dg_accs"];
+  var bucketNames = rawData["buckets"];
+  var i;
+
+  window.chartType = rawData["chart_type"];
+  window.dataPoints = [];
+
+  window.sortOrderLink = document.getElementById("sort-order-link");
+  if(window.sortOrderLink) {
+    window.sortOrderLink.addEventListener("click", toggleSortOrder);
+  }
+
+  for(i = 0; i < bucketNames.length; i++) {
+    window.dataPoints.push({
+      id: i,
+      bucket: bucketNames[i],
+      prodAcc: prodAccs[i],
+      dgAcc: dgAccs[i]
+    });
+  }
+
+  renderDashboard();
+}
+
+export function toggleSortOrder(event) {
+  event.preventDefault();
+  if(window.sortOrderLink.getAttribute("data-sort-order") == "by_id") {
+    window.sortOrderLink.innerText = "Sorted By Accuracy";
+    window.sortOrderLink.setAttribute("data-sort-order", "by_accuracy");
+  } else {
+    window.sortOrderLink.innerText = "Sorted By Route Order";
+    window.sortOrderLink.setAttribute("data-sort-order", "by_id");
+  }
+
+  renderDashboard();
 }

--- a/assets/js/chart.js
+++ b/assets/js/chart.js
@@ -30,7 +30,7 @@ export function bindFormLinks(accuracyForm) {
   bindChartRangeLink('link-by_station', 'By Station');
 }
 
-export function renderDashboard() {
+function renderDashboard() {
   var sortedProdAccs;
   var sortedDgAccs;
   var sortedBucketNames;
@@ -191,7 +191,7 @@ export function setupDashboard() {
   renderDashboard();
 }
 
-export function toggleSortOrder(event) {
+function toggleSortOrder(event) {
   event.preventDefault();
   if(window.sortOrderLink.getAttribute("data-sort-order") == "by_id") {
     window.sortOrderLink.innerText = "Sorted By Accuracy";

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -126,6 +126,10 @@
         <% end %>
       </div>
 
+      <%= if f.params["chart_range"] == "By Station" do %>
+        <%= content_tag :a, "Sorted By Route Order", id: "sort-order-link", class: "sort-order-link", "data-sort-order": "by_id", href: "#" %>
+      <% end %>
+
       <div data-prediction-accuracy class="chart" id="chart-prediction-accuracy"></div>
       <table class="table">
         <tr>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[3] Prediction Analyzer sort by accuracy](https://app.asana.com/0/584764604969369/1114524503205260)

Added a button-style link to the "By Station" view that sorts the chart by either accuracy or route ID, without the need for a page refresh.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
