### PR TITLE
Correct environment for dev-green CR predictions

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -78,7 +78,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
             body
             |> Jason.decode!()
             |> Map.get("data")
-            |> parse_commuter_rail("prod")
+            |> parse_commuter_rail(state.environment)
             |> Enum.into(%{}, fn v -> {v.id, v} end)
             |> Comparator.compare(state.commuter_rail_vehicles)
 
@@ -110,9 +110,10 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     []
   end
 
-  defp parse_commuter_rail(data, _env) do
+  @spec parse_commuter_rail([map()], String.t()) :: [PredictionAnalyzer.VehiclePositions.Vehicle]
+  defp parse_commuter_rail(data, env) do
     Enum.flat_map(data, fn d ->
-      case Vehicle.parse_commuter_rail(d) do
+      case Vehicle.parse_commuter_rail(d, env) do
         {:ok, vehicle} -> [vehicle]
         _ -> []
       end

--- a/lib/prediction_analyzer/vehicle_positions/vehicle.ex
+++ b/lib/prediction_analyzer/vehicle_positions/vehicle.ex
@@ -77,38 +77,42 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
     :error
   end
 
-  def parse_commuter_rail(%{
-        "attributes" => %{
-          "current_status" => current_status,
-          "direction_id" => direction_id,
-          "label" => label,
-          "updated_at" => updated_at
-        },
-        "id" => vehicle_id,
-        "relationships" => %{
-          "route" => %{
-            "data" => %{
-              "id" => route_id
-            }
+  @spec parse_commuter_rail(map(), String.t()) :: {:ok, __MODULE__.t()} | :error
+  def parse_commuter_rail(
+        %{
+          "attributes" => %{
+            "current_status" => current_status,
+            "direction_id" => direction_id,
+            "label" => label,
+            "updated_at" => updated_at
           },
-          "stop" => %{
-            "data" => %{
-              "id" => stop_id
-            }
-          },
-          "trip" => %{
-            "data" => %{
-              "id" => trip_id
+          "id" => vehicle_id,
+          "relationships" => %{
+            "route" => %{
+              "data" => %{
+                "id" => route_id
+              }
+            },
+            "stop" => %{
+              "data" => %{
+                "id" => stop_id
+              }
+            },
+            "trip" => %{
+              "data" => %{
+                "id" => trip_id
+              }
             }
           }
-        }
-      }) do
+        },
+        env
+      ) do
     {:ok, timestamp, _offset} = updated_at |> DateTime.from_iso8601()
 
     {:ok,
      %__MODULE__{
        id: vehicle_id,
-       environment: "prod",
+       environment: env,
        label: label,
        is_deleted: false,
        trip_id: trip_id,
@@ -120,7 +124,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
      }}
   end
 
-  def parse_commuter_rail(_), do: :error
+  def parse_commuter_rail(_data, _env), do: :error
 
   defp status_atom("INCOMING_AT"), do: :INCOMING_AT
   defp status_atom("IN_TRANSIT_TO"), do: :IN_TRANSIT_TO


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[3] Investigate "one departure, multiple updates" warnings for CR](https://app.asana.com/0/584764604969369/1116724771942026)

Prediction analyzer uses two separate `PredictionAnalyzer.VehiclePositions.Tracker` workers, one to get subway & CR data for prod, one to get data for dev-green. However, the code to parse the API responses for CR data had the "prod" environment hardcoded in, as opposed to using the environment from the worker's state. Corrected.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
