### PR TITLE
Don't try to fetch dev-green CR positions

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -63,6 +63,10 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     {:noreply, %{state | subway_vehicles: new_vehicles}}
   end
 
+  def handle_info(:track_commuter_rail_vehicles, %{environment: "dev-green"} = state) do
+    {:noreply, state}
+  end
+
   def handle_info(:track_commuter_rail_vehicles, state) do
     url_path = "vehicles"
 

--- a/test/prediction_analyzer/vehicle_positions/tracker_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/tracker_test.exs
@@ -102,6 +102,17 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
 
       assert log =~ "Could not download commuter rail vehicles"
     end
+
+    test "does nothing on dev-green" do
+      state = %{
+        aws_vehicle_positions_url: "vehiclepositions",
+        environment: "dev-green",
+        subway_vehicles: %{},
+        commuter_rail_vehicles: %{}
+      }
+
+      assert Tracker.handle_info(:track_commuter_rail_vehicles, state) == {:noreply, state}
+    end
   end
 
   defmodule NotifyGet do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[3] Investigate "one departure, multiple updates" warnings for CR](https://app.asana.com/0/584764604969369/1116724771942026)

Prediction analyzer uses two separate `PredictionAnalyzer.VehiclePositions.Tracker` workers, one to get subway & CR data for prod, one to get data for dev-green. However, the code to parse the API responses for CR data had the "prod" environment hardcoded in, which makes sense since there isn't really any CR dev-green data. The `Tracker` now checks its environment when asked to load CR data, and does nothing if in dev-green.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
