### PR TITLE
Use If-Modified-Since header when querying CR positions

### DIFF
--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -119,7 +119,11 @@ defmodule FakeHTTPoison do
       ]
     }
 
-    {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(body)}}
+    headers = [
+      {"last-modified", "Sat, 10 Sep 1977 08:25:00 GMT"}
+    ]
+
+    {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(body), headers: headers}}
   end
 
   def get!("https://prod.example.com/mbta-gtfs-s3/rtr/TripUpdates_enhanced.json" = url) do

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -193,7 +193,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     Process.send_after(pid, :track_commuter_rail_vehicles, 10_500)
   end
 
-  @spec extract_last_modified([tuple()]) :: String.t() | nil
+  @spec extract_last_modified([{String.t(), String.t()}]) :: String.t() | nil
   defp extract_last_modified(headers) do
     case Enum.find(headers, fn {key, _value} -> String.downcase(key) == "last-modified" end) do
       {_key, value} -> value

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -162,10 +162,12 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     Application.get_env(:prediction_analyzer, :aws_vehicle_positions_url)
   end
 
+  @spec schedule_subway_fetch(pid() | atom()) :: reference
   defp schedule_subway_fetch(pid) do
     Process.send_after(pid, :track_subway_vehicles, 1_000)
   end
 
+  @spec schedule_commuter_rail_fetch(pid() | atom()) :: reference
   defp schedule_commuter_rail_fetch(pid) do
     Process.send_after(pid, :track_commuter_rail_vehicles, 10_500)
   end

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -12,9 +12,9 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
           environment: String.t(),
           aws_vehicle_positions_url: String.t(),
           subway_vehicles: vehicle_map(),
+          subway_last_modified: String.t(),
           commuter_rail_vehicles: vehicle_map(),
-          commuter_rail_last_modified: String.t(),
-          subway_last_modified: String.t()
+          commuter_rail_last_modified: String.t()
         }
 
   def start_link(_opts \\ [], args) do

--- a/lib/utilities/api_v3.ex
+++ b/lib/utilities/api_v3.ex
@@ -1,7 +1,7 @@
 defmodule PredictionAnalyzer.Utilities.APIv3 do
   @default_opts [timeout: 2000, recv_timeout: 2000]
 
-  @spec request(String.t(), Keyword.t(), Keyword.t()) :: {:error, any()} | {:ok, map()}
+  @spec request(String.t(), [tuple()], Keyword.t()) :: {:error, any()} | {:ok, map()}
   def request(path, extra_headers \\ [], opts) do
     base_url = Application.get_env(:prediction_analyzer, :api_base_url)
 

--- a/lib/utilities/api_v3.ex
+++ b/lib/utilities/api_v3.ex
@@ -1,10 +1,13 @@
 defmodule PredictionAnalyzer.Utilities.APIv3 do
   @default_opts [timeout: 2000, recv_timeout: 2000]
 
-  @spec request(String.t(), Keyword.t()) :: {:error, any()} | {:ok, map()}
-  def request(path, opts) do
+  @spec request(String.t(), Keyword.t(), Keyword.t()) :: {:error, any()} | {:ok, map()}
+  def request(path, extra_headers \\ [], opts) do
     base_url = Application.get_env(:prediction_analyzer, :api_base_url)
-    headers = api_key_headers(Application.get_env(:prediction_analyzer, :api_v3_key))
+
+    headers =
+      extra_headers ++ api_key_headers(Application.get_env(:prediction_analyzer, :api_v3_key))
+
     http_fetcher = Application.get_env(:prediction_analyzer, :http_fetcher)
 
     with {:ok, req} <-

--- a/lib/utilities/api_v3.ex
+++ b/lib/utilities/api_v3.ex
@@ -1,7 +1,8 @@
 defmodule PredictionAnalyzer.Utilities.APIv3 do
   @default_opts [timeout: 2000, recv_timeout: 2000]
 
-  @spec request(String.t(), [tuple()], Keyword.t()) :: {:error, any()} | {:ok, map()}
+  @spec request(String.t(), [{String.t(), String.t()}], Keyword.t()) ::
+          {:error, any()} | {:ok, map()}
   def request(path, extra_headers \\ [], opts) do
     base_url = Application.get_env(:prediction_analyzer, :api_base_url)
 

--- a/test/prediction_analyzer/vehicle_positions/tracker_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/tracker_test.exs
@@ -39,7 +39,6 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
         aws_vehicle_positions_url: "vehiclepositions",
         environment: "dev-green",
         subway_vehicles: %{},
-        commuter_rail_vehicles: %{},
         subway_last_modified: "Thu, 01 Jan 1970 00:00:00 GMT"
       }
 

--- a/test/prediction_analyzer/vehicle_positions/tracker_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/tracker_test.exs
@@ -54,7 +54,8 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
         aws_vehicle_positions_url: "vehiclepositions",
         environment: "prod",
         subway_vehicles: %{},
-        commuter_rail_vehicles: %{}
+        commuter_rail_vehicles: %{},
+        commuter_rail_last_modified: "Thu, 01 Jan 1970 00:00:00 GMT"
       }
 
       assert {
@@ -85,7 +86,8 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
         aws_vehicle_positions_url: "vehiclepositions",
         environment: "prod",
         subway_vehicles: %{},
-        commuter_rail_vehicles: %{}
+        commuter_rail_vehicles: %{},
+        commuter_rail_last_modified: "Thu, 01 Jan 1970 00:00:00 GMT"
       }
 
       log =
@@ -96,7 +98,8 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
                       aws_vehicle_positions_url: "vehiclepositions",
                       environment: "prod",
                       subway_vehicles: %{},
-                      commuter_rail_vehicles: %{}
+                      commuter_rail_vehicles: %{},
+                      commuter_rail_last_modified: "Thu, 01 Jan 1970 00:00:00 GMT"
                     }}
         end)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[2] analyzer: Send if-modified-since headers when querying API](https://app.asana.com/0/584764604969369/1118061165588451)

In an attempt to reduce the number of "One departure, multiple update" warnings when getting CR positions, we make use of the If-Modified-Since header when requesting CR positions from the API, to avoid overwriting more recent state with less recent.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
