### PR TITLE
Remove empty parentheses from CR stop names

### DIFF
--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -48,7 +48,16 @@ defmodule FakeHTTPoison do
         params: %{"filter[route_type]" => "2"}
       ) do
     body = %{
-      "data" => []
+      "data" => [
+        %{
+          "id" => "Andover",
+          "attributes" => %{
+            "description" => nil,
+            "name" => "Andover",
+            "platform_name" => nil
+          }
+        }
+      ]
     }
 
     {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(body)}}

--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -56,14 +56,6 @@ defmodule FakeHTTPoison do
             "name" => "Andover",
             "platform_name" => nil
           }
-        },
-        %{
-          "id" => "99999999",
-          "attributes" => %{
-            "description" => nil,
-            "name" => nil,
-            "platform_name" => nil
-          }
         }
       ]
     }

--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -56,6 +56,14 @@ defmodule FakeHTTPoison do
             "name" => "Andover",
             "platform_name" => nil
           }
+        },
+        %{
+          "id" => "99999999",
+          "attributes" => %{
+            "description" => nil,
+            "name" => nil,
+            "platform_name" => nil
+          }
         }
       ]
     }

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -52,7 +52,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
     {:reply, stop_name, state}
   end
 
-  def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
+  def handle_call({:get_stop_name, _mode, stop_id}, _from, state) do
     {:reply, stop_id, state}
   end
 

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -38,7 +38,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
     stop = state[mode][stop_id]
 
-    IO.puts("stop = #{inspect(stop)} and stop = #{inspect(stop)}")
+    IO.puts("stop_id = #{inspect(stop_id)} and stop = #{inspect(stop)}")
 
     stop_name =
       if stop do

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -36,16 +36,17 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   end
 
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
-    case state[mode][stop_id] do
-      nil ->
-        stop_id
+    stop_name =
+      case state[mode][stop_id] do
+        nil ->
+          stop_id
 
-      %{platform_name: nil} = stop ->
-        stop.name
+        %{platform_name: nil} = stop ->
+          stop.name
 
-      stop ->
-        "#{stop.name} (#{stop.platform_name})"
-    end
+        stop ->
+          "#{stop.name} (#{stop.platform_name})"
+      end
 
     {:reply, stop_name, state}
   end

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -37,7 +37,16 @@ defmodule PredictionAnalyzer.StopNameFetcher do
 
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
     stop = state[mode][stop_id]
-    stop_name = if stop, do: "#{stop.name} (#{stop.platform_name})", else: stop_id
+    stop_name =
+      if stop do
+        if stop.platform_name do
+          "#{stop.name} (#{stop.platform_name})"
+        else
+          "#{stop.name}"
+        end
+      else
+        stop_id
+      end
     {:reply, stop_name, state}
   end
 

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -38,7 +38,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
     stop = state[mode][stop_id]
 
-    IO.puts("stop_name = #{stop_name} and stop = #{inspect(stop)}")
+    IO.puts("stop = #{inspect(stop)} and stop = #{inspect(stop)}")
 
     stop_name =
       if stop do

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -36,18 +36,16 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   end
 
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
-    stop = state[mode][stop_id]
-
-    stop_name =
-      if stop do
-        if stop.platform_name do
-          "#{stop.name} (#{stop.platform_name})"
-        else
-          "#{stop.name}"
-        end
-      else
+    case state[mode][stop_id] do
+      nil ->
         stop_id
-      end
+
+      %{platform_name: nil} ->
+        stop.name
+
+      _ ->
+        "#{stop.name} (#{stop.platform_name})"
+    end
 
     {:reply, stop_name, state}
   end

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -38,6 +38,8 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
     stop = state[mode][stop_id]
 
+    IO.puts("stop_name = #{stop_name} and stop = #{inspect(stop)}")
+
     stop_name =
       if stop do
         if stop.platform_name do

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -35,7 +35,8 @@ defmodule PredictionAnalyzer.StopNameFetcher do
     {:reply, description_map, state}
   end
 
-  def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
+  def handle_call({:get_stop_name, mode, stop_id}, _from, state)
+      when mode in [:commuter_rail, :subway] do
     stop_name =
       case state[mode][stop_id] do
         nil ->
@@ -49,6 +50,10 @@ defmodule PredictionAnalyzer.StopNameFetcher do
       end
 
     {:reply, stop_name, state}
+  end
+
+  def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
+    {:reply, stop_id, state}
   end
 
   def handle_info(:load_stop_data, _state) do

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -38,8 +38,6 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
     stop = state[mode][stop_id]
 
-    IO.puts("stop_id = #{inspect(stop_id)} and stop = #{inspect(stop)}")
-
     stop_name =
       if stop do
         if stop.platform_name do

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -40,10 +40,10 @@ defmodule PredictionAnalyzer.StopNameFetcher do
       nil ->
         stop_id
 
-      %{platform_name: nil} ->
+      %{platform_name: nil} = stop ->
         stop.name
 
-      _ ->
+      stop ->
         "#{stop.name} (#{stop.platform_name})"
     end
 

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -37,6 +37,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
 
   def handle_call({:get_stop_name, mode, stop_id}, _from, state) do
     stop = state[mode][stop_id]
+
     stop_name =
       if stop do
         if stop.platform_name do
@@ -47,6 +48,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
       else
         stop_id
       end
+
     {:reply, stop_name, state}
   end
 

--- a/test/prediction_analyzer/stop_name_fetcher_test.exs
+++ b/test/prediction_analyzer/stop_name_fetcher_test.exs
@@ -44,7 +44,7 @@ defmodule PredictionAnalyzer.StopNameFetcherTest do
       assert StopNameFetcher.get_stop_name(:commuter_rail, "Andover") == "Andover"
     end
 
-    test "returns the id if the stop doesn't have a name" do
+    test "returns the id if the stop isn't found" do
       StopNameFetcher.start_link(name: PredictionAnalyzer.StopNameFetcher)
 
       assert StopNameFetcher.get_stop_name(:commuter_rail, "99999999") == "99999999"

--- a/test/prediction_analyzer/stop_name_fetcher_test.exs
+++ b/test/prediction_analyzer/stop_name_fetcher_test.exs
@@ -37,5 +37,11 @@ defmodule PredictionAnalyzer.StopNameFetcherTest do
       assert StopNameFetcher.get_stop_name(:subway, "70238") ==
                "Cleveland Circle (Park Street & North)"
     end
+
+    test "returns the name with no platform code if the stop doesn't have a platform code" do
+      StopNameFetcher.start_link(name: PredictionAnalyzer.StopNameFetcher)
+
+      assert StopNameFetcher.get_stop_name(:commuter_rail, "Andover") == "Andover"
+    end
   end
 end

--- a/test/prediction_analyzer/stop_name_fetcher_test.exs
+++ b/test/prediction_analyzer/stop_name_fetcher_test.exs
@@ -49,5 +49,11 @@ defmodule PredictionAnalyzer.StopNameFetcherTest do
 
       assert StopNameFetcher.get_stop_name(:commuter_rail, "99999999") == "99999999"
     end
+
+    test "returns the id if the mode isn't found" do
+      StopNameFetcher.start_link(name: PredictionAnalyzer.StopNameFetcher)
+
+      assert StopNameFetcher.get_stop_name(:not_a_mode, "99999999") == "99999999"
+    end
   end
 end

--- a/test/prediction_analyzer/stop_name_fetcher_test.exs
+++ b/test/prediction_analyzer/stop_name_fetcher_test.exs
@@ -43,5 +43,11 @@ defmodule PredictionAnalyzer.StopNameFetcherTest do
 
       assert StopNameFetcher.get_stop_name(:commuter_rail, "Andover") == "Andover"
     end
+
+    test "returns the id if the stop doesn't have a name" do
+      StopNameFetcher.start_link(name: PredictionAnalyzer.StopNameFetcher)
+
+      assert StopNameFetcher.get_stop_name(:commuter_rail, "99999999") == "99999999"
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [analyzer: why do commuter-rail stations have empty parentheses at the end?](https://app.asana.com/0/107495983514632/1117239379853577)

Handled case where `stop.platform_name` is nil

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
