### PR TITLE
Display stop ID when other fields are ambiguous

### DIFF
--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -33,6 +33,38 @@ defmodule FakeHTTPoison do
             "name" => "Jackson Sq",
             "platform_name" => "Oak Grove"
           }
+        },
+        %{
+          "id" => "70150",
+          "attributes" => %{
+            "description" => "Kenmore - Green Line - Park Street & North",
+            "name" => "Kenmore",
+            "platform_name" => "Park Street & North"
+          }
+        },
+        %{
+          "id" => "71150",
+          "attributes" => %{
+            "description" => "Kenmore - Green Line - Park Street & North",
+            "name" => "Kenmore",
+            "platform_name" => "Park Street & North"
+          }
+        },
+        %{
+          "id" => "dummystop1",
+          "attributes" => %{
+            "description" => "Dummy Stop Description",
+            "name" => "Dummy Stop Name",
+            "platform_name" => nil
+          }
+        },
+        %{
+          "id" => "dummystop2",
+          "attributes" => %{
+            "description" => "Dummy Stop Description",
+            "name" => "Dummy Stop Name",
+            "platform_name" => nil
+          }
         }
       ]
     }

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -97,7 +97,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   defp parse_response(http_response) do
     {:ok, body} = Jason.decode(http_response.body)
 
-    unique_info =
+    unique_info_map =
       body["data"]
       |> Enum.reduce(%{}, fn stop, acc ->
         Map.update(
@@ -120,7 +120,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
         platform_name: stop["attributes"]["platform_name"]
       }
 
-      {stop["id"], Map.merge(stop_info, %{unique_info?: unique_info[stop_info]})}
+      {stop["id"], Map.merge(stop_info, %{unique_info?: unique_info_map[stop_info]})}
     end)
     |> Enum.into(%{})
   end

--- a/lib/prediction_analyzer/stop_name_fetcher.ex
+++ b/lib/prediction_analyzer/stop_name_fetcher.ex
@@ -2,7 +2,12 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   require Logger
   use GenServer
 
-  @type state() :: %{PredictionAnalyzer.Utilities.mode() => %{String.t() => String.t()}}
+  @type stop_info :: %{
+          description: String.t(),
+          name: String.t(),
+          platform_name: String.t()
+        }
+  @type state() :: %{PredictionAnalyzer.Utilities.mode() => %{String.t() => stop_info()}}
 
   @spec start_link([any]) :: {:ok, pid}
   def start_link(opts \\ []) do
@@ -43,10 +48,18 @@ defmodule PredictionAnalyzer.StopNameFetcher do
           stop_id
 
         %{platform_name: nil} = stop ->
-          stop.name
+          if unique_stop_info?(state[mode], state[mode][stop_id]) do
+            stop.name
+          else
+            "#{stop.name} - #{stop_id}"
+          end
 
         stop ->
-          "#{stop.name} (#{stop.platform_name})"
+          if unique_stop_info?(state[mode], state[mode][stop_id]) do
+            "#{stop.name} (#{stop.platform_name})"
+          else
+            "#{stop.name} (#{stop.platform_name}) - #{stop_id}"
+          end
       end
 
     {:reply, stop_name, state}
@@ -60,7 +73,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
     {:noreply, %{subway: load_stop_data(:subway), commuter_rail: load_stop_data(:commuter_rail)}}
   end
 
-  @spec load_stop_data(PredictionAnalyzer.Utilities.mode()) :: state
+  @spec load_stop_data(PredictionAnalyzer.Utilities.mode()) :: %{String.t() => stop_info()}
   defp load_stop_data(mode) do
     path = "stops"
     params = get_params(mode)
@@ -79,7 +92,7 @@ defmodule PredictionAnalyzer.StopNameFetcher do
   defp get_params(:subway), do: %{"filter[route_type]" => "0,1"}
   defp get_params(:commuter_rail), do: %{"filter[route_type]" => "2"}
 
-  @spec parse_response(%HTTPoison.Response{}) :: state
+  @spec parse_response(%HTTPoison.Response{}) :: %{String.t() => stop_info()}
   defp parse_response(http_response) do
     {:ok, body} = Jason.decode(http_response.body)
 
@@ -93,5 +106,24 @@ defmodule PredictionAnalyzer.StopNameFetcher do
        }}
     end)
     |> Enum.into(%{})
+  end
+
+  @spec unique_stop_info?(%{String.t() => stop_info()}, stop_info()) :: boolean()
+  defp unique_stop_info?(mode_state, stop_info) do
+    mode_state
+    |> Map.values()
+    |> do_unique_stop_id?(stop_info, false)
+  end
+
+  @spec do_unique_stop_id?([stop_info()], stop_info(), boolean()) :: boolean()
+  defp do_unique_stop_id?([], _, _), do: true
+  defp do_unique_stop_id?([stop_info | _], stop_info, true), do: false
+
+  defp do_unique_stop_id?([stop_info | stop_infos], stop_info, false) do
+    do_unique_stop_id?(stop_infos, stop_info, true)
+  end
+
+  defp do_unique_stop_id?([_ | stop_infos], stop_info, seen?) do
+    do_unique_stop_id?(stop_infos, stop_info, seen?)
   end
 end

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -148,6 +148,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
       |> Map.put(:dg_accs, acc[:dg_accs] ++ dg_accuracy)
     end)
     |> Map.put(:chart_type, filter_params["chart_range"] || "Hourly")
+    |> IO.inspect(label: :chart_data)
   end
 
   @spec time_filters_present?(map()) :: boolean()

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -148,7 +148,6 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
       |> Map.put(:dg_accs, acc[:dg_accs] ++ dg_accuracy)
     end)
     |> Map.put(:chart_type, filter_params["chart_range"] || "Hourly")
-    |> IO.inspect(label: :chart_data)
   end
 
   @spec time_filters_present?(map()) :: boolean()

--- a/test/prediction_analyzer/stop_name_fetcher_test.exs
+++ b/test/prediction_analyzer/stop_name_fetcher_test.exs
@@ -7,7 +7,11 @@ defmodule PredictionAnalyzer.StopNameFetcherTest do
   @expected_descriptions %{
     "70238" => "Cleveland Circle - Green Line - Park Street & North",
     "70007" => "Jackson Square - Orange Line - Oak Grove",
-    "70197" => "Park Street - Green Line - (C) Cleveland Circle"
+    "70197" => "Park Street - Green Line - (C) Cleveland Circle",
+    "70150" => "Kenmore - Green Line - Park Street & North",
+    "71150" => "Kenmore - Green Line - Park Street & North",
+    "dummystop1" => "Dummy Stop Description",
+    "dummystop2" => "Dummy Stop Description"
   }
 
   test "starts up with no issue" do
@@ -54,6 +58,20 @@ defmodule PredictionAnalyzer.StopNameFetcherTest do
       StopNameFetcher.start_link(name: PredictionAnalyzer.StopNameFetcher)
 
       assert StopNameFetcher.get_stop_name(:not_a_mode, "99999999") == "99999999"
+    end
+
+    test "include the stop ID if the description and platform name are ambiguous" do
+      StopNameFetcher.start_link(name: PredictionAnalyzer.StopNameFetcher)
+
+      assert StopNameFetcher.get_stop_name(:subway, "70150") ==
+               "Kenmore (Park Street & North) - 70150"
+    end
+
+    test "include the stop ID if the description is ambiguous (no platform name case)" do
+      StopNameFetcher.start_link(name: PredictionAnalyzer.StopNameFetcher)
+
+      assert StopNameFetcher.get_stop_name(:subway, "dummystop1") ==
+               "Dummy Stop Name - dummystop1"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Fix issue where some stops in prediction analyzer "by station" view have more than 2 bars associated](https://app.asana.com/0/584764604969369/1116298449952961/f)

It turns out there isn't an easy fix for the underlying GTFS data, so let's disambiguate with the stop ID when the other fields are all the same.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
