### PR TITLE
Add ME and RMSE columns and calculations

### DIFF
--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -16,6 +16,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
     field(:bin, :string)
     field(:num_predictions, :integer)
     field(:num_accurate_predictions, :integer)
+    field(:mean_error, :float)
+    field(:root_mean_squared_error, :float)
   end
 
   def new_insert_changeset(params \\ %{}) do

--- a/lib/prediction_analyzer/prediction_accuracy/query.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/query.ex
@@ -133,7 +133,9 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         arrival_departure,
         bin,
         num_predictions,
-        num_accurate_predictions
+        num_accurate_predictions,
+        mean_error,
+        root_mean_squared_error
       ) (
       SELECT
         $11 AS environment,
@@ -152,7 +154,13 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
               AND ve.#{arrival_or_departure_time_column} - p.#{arrival_or_departure_time_column} < $8 THEN 1
             ELSE 0
           END
-        ) AS num_accurate_predictions
+        ) AS num_accurate_predictions,
+        AVG(ve.#{arrival_or_departure_time_column} - p.#{arrival_or_departure_time_column}) AS mean_error,
+        SQRT(
+          AVG(
+            (ve.#{arrival_or_departure_time_column} - p.#{arrival_or_departure_time_column})^2
+          )
+        ) AS root_mean_squared_error
       FROM predictions AS p
       LEFT JOIN vehicle_events AS ve ON ve.id = p.vehicle_event_id
       WHERE p.file_timestamp > $9
@@ -163,7 +171,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         AND p.#{arrival_or_departure_time_column} - p.file_timestamp >= $5
         AND p.#{arrival_or_departure_time_column} - p.file_timestamp < $6
       GROUP BY p.route_id, p.stop_id, p.direction_id
-      )
+    )
     "
   end
 end

--- a/lib/prediction_analyzer/weekly_accuracies/query.ex
+++ b/lib/prediction_analyzer/weekly_accuracies/query.ex
@@ -88,7 +88,9 @@ defmodule PredictionAnalyzer.WeeklyAccuracies.Query do
         arrival_departure,
         bin,
         num_predictions,
-        num_accurate_predictions
+        num_accurate_predictions,
+        mean_error,
+        root_mean_squared_error
       ) (
       SELECT
         environment,
@@ -99,7 +101,11 @@ defmodule PredictionAnalyzer.WeeklyAccuracies.Query do
         arrival_departure,
         bin,
         sum(num_predictions) as num_predictions,
-        sum(num_accurate_predictions) as num_accurate_predictions
+        sum(num_accurate_predictions) as num_accurate_predictions,
+        sum(mean_error * num_predictions) / sum(num_predictions) as mean_error,
+        sqrt(
+          sum(root_mean_squared_error^2 * num_predictions) / sum(num_predictions)
+        ) as root_mean_squared_error
       FROM prediction_accuracy
       WHERE service_date > $1
         AND service_date < $2

--- a/lib/prediction_analyzer/weekly_accuracies/weekly_accuracies.ex
+++ b/lib/prediction_analyzer/weekly_accuracies/weekly_accuracies.ex
@@ -15,6 +15,8 @@ defmodule PredictionAnalyzer.WeeklyAccuracies.WeeklyAccuracies do
     field(:bin, :string)
     field(:num_predictions, :integer)
     field(:num_accurate_predictions, :integer)
+    field(:mean_error, :float)
+    field(:root_mean_squared_error, :float)
   end
 
   @spec new_insert_changeset(map()) :: Ecto.Schema.t()

--- a/priv/repo/migrations/20190624192925_add_mse_rmse_columns.exs
+++ b/priv/repo/migrations/20190624192925_add_mse_rmse_columns.exs
@@ -3,13 +3,13 @@ defmodule PredictionAnalyzer.Repo.Migrations.AddMseRmseColumns do
 
   def change do
     alter table("prediction_accuracy") do
-      add(:mean_error, :real, null: false, default: 0.0)
-      add(:root_mean_squared_error, :real, null: false, default: 0.0)
+      add(:mean_error, :real)
+      add(:root_mean_squared_error, :real)
     end
 
     alter table("weekly_accuracies") do
-      add(:mean_error, :real, null: false, default: 0.0)
-      add(:root_mean_squared_error, :real, null: false, default: 0.0)
+      add(:mean_error, :real)
+      add(:root_mean_squared_error, :real)
     end
   end
 end

--- a/priv/repo/migrations/20190624192925_add_mse_rmse_columns.exs
+++ b/priv/repo/migrations/20190624192925_add_mse_rmse_columns.exs
@@ -1,0 +1,15 @@
+defmodule PredictionAnalyzer.Repo.Migrations.AddMseRmseColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table("prediction_accuracy") do
+      add(:mean_error, :real, null: false, default: 0.0)
+      add(:root_mean_squared_error, :real, null: false, default: 0.0)
+    end
+
+    alter table("weekly_accuracies") do
+      add(:mean_error, :real, null: false, default: 0.0)
+      add(:root_mean_squared_error, :real, null: false, default: 0.0)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Part of [📈  Add average deviation as a metric](https://app.asana.com/0/584764604969369/1113586286577022)

Adds the mean error and root mean squared error to our predictions. A subsequent PR will expose this data in the front end.

One little tricky bit I worked the math out for that I'd like double checked is how to aggregate multiple errors / rmses.

Mean error:

If 5 predictions had a mean error of 10 and 2 predictions had a mean error of 8, then the overall mean error is `(5*10 + 2*8) / (5+2)`.

RMSE:

If 5 predictions had an RMSE of 10 and 2 predictions had an RMSE of 8, then the overall RMSE is: 
`sqrt((5*10^2 + 2*8^2) / (5+2))`.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
