### PR TITLE
Split 6-12 min bucket into more granularity

### DIFF
--- a/lib/prediction_analyzer/filters.ex
+++ b/lib/prediction_analyzer/filters.ex
@@ -12,7 +12,9 @@ defmodule PredictionAnalyzer.Filters do
     %{
       "0-3 min" => {-30, 180, -60, 60},
       "3-6 min" => {180, 360, -90, 120},
-      "6-12 min" => {360, 720, -150, 210},
+      "6-8 min" => {360, 720, -150, 210},
+      "8-10 min" => {360, 720, -150, 210},
+      "10-12 min" => {360, 720, -150, 210},
       "12-30 min" => {720, 1800, -240, 360}
     }
   end
@@ -65,13 +67,18 @@ defmodule PredictionAnalyzer.Filters do
 
   def filter_by_direction(q, _), do: {:ok, q}
 
-  @spec filter_by_bin(Ecto.Query.t(), any()) :: {:ok, Ecto.Query.t()} | {:error, String.t()}
-  def filter_by_bin(q, bin) do
-    if Map.has_key?(bins(), bin) do
-      {:ok, from(acc in q, where: acc.bin == ^bin)}
-    else
-      {:ok, q}
-    end
+  @spec filter_by_bin(Ecto.Query.t(), String.t()) :: {:ok, Ecto.Query.t()} | {:error, String.t()}
+  def filter_by_bin(q, "All") do
+    {:ok, q}
+  end
+
+  def filter_by_bin(q, bins) when byte_size(bins) > 0 do
+    bins = String.split(bins, ",")
+    {:ok, from(acc in q, where: acc.bin in ^bins)}
+  end
+
+  def filter_by_bin(q, _bins) do
+    {:ok, q}
   end
 
   @spec filter_by_timeframe(Ecto.Query.t(), any(), any(), any(), any()) ::

--- a/lib/prediction_analyzer_web/views/accuracy_view.ex
+++ b/lib/prediction_analyzer_web/views/accuracy_view.ex
@@ -55,6 +55,7 @@ defmodule PredictionAnalyzerWeb.AccuracyView do
       |> hd
       |> String.to_integer()
     end)
+    |> Kernel.++([{"6-12 min", "6-8 min,8-10 min,10-12 min,6-12 min"}])
   end
 
   @spec chart_range_scope_header(String.t()) :: String.t()

--- a/priv/repo/migrations/20190701174220_add_buckets_to_accuracy_tables.exs
+++ b/priv/repo/migrations/20190701174220_add_buckets_to_accuracy_tables.exs
@@ -1,0 +1,15 @@
+defmodule PredictionAnalyzer.Repo.Migrations.AddBucketsToAccuracyTables do
+  use Ecto.Migration
+  # adding value to enum type can't be done in a transaction
+  @disable_ddl_transaction true
+
+  def up do
+    execute("alter type prediction_bin add value '6-8 min'")
+    execute("alter type prediction_bin add value '8-10 min'")
+    execute("alter type prediction_bin add value '10-12 min'")
+  end
+
+  def down do
+    # can't easily remove an enum type value
+  end
+end

--- a/priv/repo/migrations/20190701174220_add_buckets_to_accuracy_tables.exs
+++ b/priv/repo/migrations/20190701174220_add_buckets_to_accuracy_tables.exs
@@ -10,6 +10,8 @@ defmodule PredictionAnalyzer.Repo.Migrations.AddBucketsToAccuracyTables do
   end
 
   def down do
-    # can't easily remove an enum type value
+    # can't remove an enum type value without recreating type and
+    # updating all rows.
+    raise Ecto.MigrationError
   end
 end

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -54,10 +54,11 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
       acc2 = %{@prediction_accuracy | stop_id: "some_stop"}
       acc3 = %{@prediction_accuracy | route_id: "some_route"}
       acc4 = %{@prediction_accuracy | arrival_departure: "departure"}
-      acc5 = %{@prediction_accuracy | bin: "6-12 min"}
+      acc5 = %{@prediction_accuracy | bin: "6-8 min"}
       acc6 = %{@prediction_accuracy | direction_id: 1}
 
       base_params = %{
+        "bin" => "All",
         "chart_range" => "Hourly",
         "service_date" => Timex.local() |> Date.to_string()
       }
@@ -98,7 +99,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
       q = from(acc in accs, [])
       assert [%{id: ^acc4_id}] = execute_query(q)
 
-      {accs, nil} = PredictionAccuracy.filter(Map.merge(base_params, %{"bin" => "6-12 min"}))
+      {accs, nil} = PredictionAccuracy.filter(Map.merge(base_params, %{"bin" => "6-8 min"}))
       q = from(acc in accs, [])
       assert [%{id: ^acc5_id}] = execute_query(q)
 
@@ -122,6 +123,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       {accs, nil} =
         PredictionAccuracy.filter(%{
+          "bin" => "All",
           "chart_range" => "Hourly",
           "service_date" => Date.to_string(yesterday)
         })
@@ -132,6 +134,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       {accs, nil} =
         PredictionAccuracy.filter(%{
+          "bin" => "All",
           "chart_range" => "Hourly",
           "service_date" => Date.to_string(day_before)
         })
@@ -141,7 +144,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
       assert [%{id: ^acc2_id}] = execute_query(q)
 
       assert {_, "No start or end date given."} =
-               PredictionAccuracy.filter(%{"chart_range" => "Daily"})
+               PredictionAccuracy.filter(%{"bin" => "All", "chart_range" => "Daily"})
     end
 
     test "can customize range of date filter, with max of 4 weeks" do
@@ -156,6 +159,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       {accs, nil} =
         PredictionAccuracy.filter(%{
+          "bin" => "All",
           "chart_range" => "Daily",
           "date_start" => "2018-01-01",
           "date_end" => "2018-01-14"
@@ -166,6 +170,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       {accs, nil} =
         PredictionAccuracy.filter(%{
+          "bin" => "All",
           "chart_range" => "Daily",
           "date_start" => "2018-01-01",
           "date_end" => "2018-01-21"
@@ -176,6 +181,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       assert {_accs, "Dates can't be more than 5 weeks apart"} =
                PredictionAccuracy.filter(%{
+                 "bin" => "All",
                  "chart_range" => "Daily",
                  "date_start" => "2018-01-01",
                  "date_end" => "2018-02-28"

--- a/test/prediction_analyzer_web/views/accuracy_view_test.exs
+++ b/test/prediction_analyzer_web/views/accuracy_view_test.exs
@@ -20,7 +20,15 @@ defmodule PredictionAnalyzerWeb.AccuracyViewTest do
   end
 
   test "bin_options/0 returns bin names in the proper order" do
-    assert AccuracyView.bin_options() == ["0-3 min", "3-6 min", "6-12 min", "12-30 min"]
+    assert AccuracyView.bin_options() == [
+             "0-3 min",
+             "3-6 min",
+             "6-8 min",
+             "8-10 min",
+             "10-12 min",
+             "12-30 min",
+             {"6-12 min", "6-8 min,8-10 min,10-12 min,6-12 min"}
+           ]
   end
 
   test "chart_range_scope_header/1 returns the proper value" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Split 6-12 bin to 6-8, 8-10, 10-12](https://app.asana.com/0/584764604969369/1128108664093986)

Splits the 6-12 min bucket apart into 6-8, 8-10, and 10-12 mins.

In postgres, this column was an enum, so it requires a migration to alter the type to add the new values. This can't be run in a transaction so I had to use `@disable_ddl_transaction`. Unfortunately, there's no good way to _remove_ values from a postgres type enum, so while the `up/0` adds them, the `down/0` does nothing. The work around seems to be to make a new type, and alter all the columns with the old type to the new one, then delete the old type, and then rename the new type. But given we'd be dealing with millions of rows, that's not something I want to have done automatically and nonchalantly in a migration rollback. If there's an issue with the migration for some reason, we can tackle how to solve it specifically.

The aggregation code change was very small. Updating `bins/0` to specify the new bins and remove the old one.

I updated the query to take a comma separated list of bins, a la route_id, and then added a new option to the bin select "6-12 min" which has a value of "6-8 min,8-10 min,10-12 min,6-12 min", so that the "6-12 bin" is comparable before and after the split.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
