### PR TITLE
run the pruner more often

### DIFF
--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -25,7 +25,6 @@ defmodule PredictionAnalyzer.Pruner do
     unix_cutoff =
       Timex.local()
       |> Timex.shift(days: -28)
-      |> Timex.set(hour: 3, minute: 0, second: 0)
       |> DateTime.to_unix()
 
     {time, _} =
@@ -68,6 +67,6 @@ defmodule PredictionAnalyzer.Pruner do
   end
 
   defp schedule_next_run(pid) do
-    Process.send_after(pid, :prune, Utilities.ms_to_3am(Timex.local()) + 10 * 60 * 1_000)
+    Process.send_after(pid, :prune, (Timex.local() |> DateTime.to_unix()) + 12 * 60 * 60 * 1_000)
   end
 end

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -1,7 +1,6 @@
 defmodule PredictionAnalyzer.Pruner do
   use GenServer
 
-  alias PredictionAnalyzer.Utilities
   alias PredictionAnalyzer.Repo
   alias PredictionAnalyzer.VehicleEvents.VehicleEvent
   alias PredictionAnalyzer.Predictions.Prediction

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -66,6 +66,7 @@ defmodule PredictionAnalyzer.Pruner do
     {:noreply, state}
   end
 
+  @spec schedule_next_run(pid()) :: reference()
   defp schedule_next_run(pid) do
     Process.send_after(pid, :prune, (Timex.local() |> DateTime.to_unix()) + 12 * 60 * 60 * 1_000)
   end

--- a/lib/prediction_analyzer/utilities.ex
+++ b/lib/prediction_analyzer/utilities.ex
@@ -73,22 +73,6 @@ defmodule PredictionAnalyzer.Utilities do
     end
   end
 
-  @doc """
-  Returns the number of ms to the next 3am local time.
-  """
-  def ms_to_3am(local_now) do
-    run_day =
-      if local_now.hour < 3 do
-        local_now
-      else
-        Timex.shift(local_now, days: 1)
-      end
-
-    run_day
-    |> Timex.set(hour: 3, minute: 0, second: 0, microsecond: {0, 6})
-    |> Timex.diff(local_now, :milliseconds)
-  end
-
   @spec generic_stop_id(String.t()) :: String.t()
   def generic_stop_id("Alewife-01"), do: "70061"
   def generic_stop_id("Alewife-02"), do: "70061"

--- a/test/prediction_analyzer/utilities_test.exs
+++ b/test/prediction_analyzer/utilities_test.exs
@@ -38,30 +38,6 @@ defmodule PredictionAnalyzer.UtilitiesTest do
     end
   end
 
-  describe "ms_to_3am" do
-    test "returns the milliseconds to 3am when 3am is tomorrow" do
-      timezone = Application.get_env(:prediction_analyzer, :timezone)
-
-      time =
-        timezone
-        |> Timex.now()
-        |> Timex.set(hour: 23, minute: 59, second: 0, microsecond: {0, 6})
-
-      assert Utilities.ms_to_3am(time) == 10_860_000
-    end
-
-    test "returns the milliseconds to 3am when 3am is later today" do
-      timezone = Application.get_env(:prediction_analyzer, :timezone)
-
-      time =
-        timezone
-        |> Timex.now()
-        |> Timex.set(hour: 2, minute: 59, second: 0, microsecond: {0, 6})
-
-      assert Utilities.ms_to_3am(time) == 60_000
-    end
-  end
-
   describe "get_week_range/1" do
     test "gets the date of the given time and a date one week from the given time" do
       timezone = Application.get_env(:prediction_analyzer, :timezone)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 Prediction analyzer pruning failing](https://app.asana.com/0/584764604969369/1130638623059531)

pruner ran every day at 3am before.  now every 12 hours. we will also need to run the delete query live at some point.
#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
