### PR TITLE
Handle case where data for a scope is missing from one environment

### DIFF
--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -71,6 +71,27 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
     assert response =~ "79.63%"
   end
 
+  test "GET /accuracy aggregates the results by hour, even when one environment is missing hours",
+       %{conn: conn} do
+    insert_hourly_accuracy("prod", 10, 101, 99)
+    insert_hourly_accuracy("prod", 10, 108, 102)
+    insert_hourly_accuracy("prod", 11, 225, 211)
+    insert_hourly_accuracy("prod", 11, 270, 261)
+    insert_hourly_accuracy("dev-green", 10, 401, 399)
+    insert_hourly_accuracy("dev-green", 10, 408, 302)
+    insert_hourly_accuracy("dev-green", 11, 525, 411)
+    insert_hourly_accuracy("dev-green", 11, 570, 461)
+    insert_hourly_accuracy("dev-green", 12, 216, 135)
+
+    conn = get(conn, "/accuracy")
+    conn = get(conn, redirected_to(conn))
+    response = html_response(conn, 200)
+
+    assert response =~ "216"
+    # 135 / 216
+    assert response =~ "62.5%"
+  end
+
   test "GET /accuracy defaults to hourly", %{conn: conn} do
     conn = get(conn, "/accuracy")
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📈 PA graph not rendering when data for prod or dev-green is absent](https://app.asana.com/0/584764604969369/1130926440048926/f)

Previously we had been using `Enum.zip`, which doesn't work for our use case where the two things we want to zip may have differing numbers of elements.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
