### PR TITLE
Use backoff strategy when retrying aggregation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,8 +38,6 @@ config :prediction_analyzer, PredictionAnalyzer.Repo,
 
 config :prediction_analyzer, start_workers: true
 
-config :prediction_analyzer, retry_sleep_time: 10_000
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/prediction_analyzer/prediction_accuracy/aggregator.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/aggregator.ex
@@ -4,27 +4,81 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Aggregator do
   alias PredictionAnalyzer.PredictionAccuracy.Query
   alias PredictionAnalyzer.Filters
 
+  @max_retries 4
+
+  @type t :: %{
+          retry_time_fetcher: (integer() -> integer()),
+          repo: Ecto.Repo.t()
+        }
+
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, [], opts)
   end
 
-  def init([]) do
+  def init(opts) do
+    retry_time_fetcher = opts[:retry_time_fetcher] || fn n -> retry_sleep_ms_per_attempt(n) end
+    repo = opts[:repo] || PredictionAnalyzer.Repo
     schedule_next_run(self())
-    {:ok, []}
+    {:ok, %{retry_time_fetcher: retry_time_fetcher, repo: repo}}
   end
 
   def handle_info(:aggregate, state) do
     Logger.info("Calculating prediction accuracies")
 
-    {time, _result} =
+    {time, result} =
       :timer.tc(fn ->
         timezone = Application.get_env(:prediction_analyzer, :timezone)
         current_time = Timex.now(timezone)
+        do_aggregation_with_retries(current_time, state.repo, state.retry_time_fetcher)
+      end)
 
+    if result == :ok do
+      Logger.info("Finished prediction aggregations in #{time / 1000} ms")
+    else
+      Logger.warn("Prediction aggregation failed, not retrying")
+    end
+
+    schedule_next_run(self())
+    {:noreply, state}
+  end
+
+  @spec do_aggregation_with_retries(
+          DateTime.t(),
+          Ecto.Repo.t(),
+          (integer() -> integer()),
+          integer()
+        ) :: :ok | :error
+  defp do_aggregation_with_retries(
+         current_time,
+         repo,
+         retry_time_fetcher,
+         retries \\ @max_retries
+       ) do
+    case do_aggregation(current_time, repo) do
+      :ok ->
+        :ok
+
+      :error ->
+        if retries > 0 do
+          retry_ms = retry_time_fetcher.(retries)
+          Logger.info("Prediction aggregation failed, retrying in #{retry_ms / 1000} seconds")
+          Process.sleep(retry_ms)
+
+          do_aggregation_with_retries(current_time, repo, retry_time_fetcher, retries - 1)
+        else
+          :error
+        end
+    end
+  end
+
+  @spec do_aggregation(DateTime.t(), Ecto.Repo.t()) :: :ok | :error
+  defp do_aggregation(current_time, repo) do
+    try do
+      repo.transaction(fn ->
         Enum.each(Filters.bins(), fn {bin_name, {bin_min, bin_max, bin_error_min, bin_error_max}} ->
           {:ok, r} =
             Query.calculate_aggregate_accuracy(
-              PredictionAnalyzer.Repo,
+              repo,
               current_time,
               "arrival",
               bin_name,
@@ -39,7 +93,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Aggregator do
 
           {:ok, r} =
             Query.calculate_aggregate_accuracy(
-              PredictionAnalyzer.Repo,
+              repo,
               current_time,
               "departure",
               bin_name,
@@ -54,7 +108,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Aggregator do
 
           {:ok, r} =
             Query.calculate_aggregate_accuracy(
-              PredictionAnalyzer.Repo,
+              repo,
               current_time,
               "arrival",
               bin_name,
@@ -69,7 +123,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Aggregator do
 
           {:ok, r} =
             Query.calculate_aggregate_accuracy(
-              PredictionAnalyzer.Repo,
+              repo,
               current_time,
               "departure",
               bin_name,
@@ -84,12 +138,21 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Aggregator do
         end)
       end)
 
-    Logger.info("Finished prediction aggregations in #{time / 1000} ms")
-    schedule_next_run(self())
-    {:noreply, state}
+      :ok
+    rescue
+      e in DBConnection.ConnectionError ->
+        Logger.warn("#{__MODULE__} do_aggregation #{inspect(e)}")
+        :error
+    end
   end
 
   defp schedule_next_run(pid) do
     Process.send_after(pid, :aggregate, PredictionAnalyzer.Utilities.ms_to_next_hour())
   end
+
+  @spec retry_sleep_ms_per_attempt(integer()) :: integer()
+  def retry_sleep_ms_per_attempt(4), do: 10 * 1_000
+  def retry_sleep_ms_per_attempt(3), do: 60 * 1_000
+  def retry_sleep_ms_per_attempt(2), do: 600 * 1_000
+  def retry_sleep_ms_per_attempt(1), do: 1_800 * 1_000
 end

--- a/test/prediction_analyzer/prediction_accuracy/query_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/query_test.exs
@@ -1,6 +1,5 @@
 defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
   import Ecto.Query, only: [from: 2]
   alias PredictionAnalyzer.Repo
   alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
@@ -43,12 +42,6 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
     arrival_time: nil,
     departure_time: nil
   }
-
-  defmodule FakeRepo do
-    def query(_query, _params) do
-      raise DBConnection.ConnectionError
-    end
-  end
 
   describe "calculate_aggregate_accuracy/9" do
     test "selects the right predictions based on bin and grades them accurately, for arrivals" do
@@ -236,30 +229,6 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
       assert pa.num_predictions == 4
       assert pa.num_accurate_predictions == 2
       assert pa.direction_id == 0
-    end
-
-    test "handles database failure properly" do
-      log =
-        capture_log([level: :warn], fn ->
-          :error =
-            Query.calculate_aggregate_accuracy(
-              FakeRepo,
-              Timex.local(),
-              "departure",
-              "6-12 min",
-              360,
-              720,
-              -30,
-              60,
-              "dev-green"
-            )
-        end)
-
-      base_log_msg =
-        "Elixir.PredictionAnalyzer.PredictionAccuracy.Query do_calculate_aggregate_accuracy"
-
-      assert log =~ "[warn] " <> base_log_msg
-      assert log =~ "[error] " <> base_log_msg
     end
 
     test "calculates mean error and root mean squared error correctly" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛 Address Prediction Analyzer failed aggregation errors](https://app.asana.com/0/584764604969369/1125718067018657/f)

Do the backoff with the times recommended in the ticket. I'm not super happy with making `retry_sleep_ms_per_attempt` public and just testing it directly but the alternative is actually invoking it and then having some long wait times while the tests run.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
