### PR TITLE
Log case where we fail to parse a given vehicle

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -156,8 +156,12 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
   defp parse_vehicles(%{"entity" => entities}, environment) do
     Enum.flat_map(entities, fn e ->
       case Vehicle.from_json(e, environment) do
-        {:ok, vehicle} -> [vehicle]
-        _ -> []
+        {:ok, vehicle} ->
+          [vehicle]
+
+        _ ->
+          Logger.warn("failed_to_parse_vehicle_entity #{inspect(e)}")
+          []
       end
     end)
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛 Prediction Analyzer "multiple departure" errors](https://app.asana.com/0/584764604969369/1125718067018656/f)

It looks like in many of these cases the vehicles are getting "materialized" as new, but in the concrete examples I've looked at I can't find any reason why they wouldn't be in the vehicle positions feed for an update. The one thing I can think of is if the exact structure of the vehicle entity somehow fails to match the function clause in the `PredictionAnalyzer.VehiclePositions.Vehicle.from_json` function. Logging this will allow me to test this theory.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
