### PR TITLE
Fallback to current time for arrival, if missing

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,6 +37,8 @@ config :prediction_analyzer, PredictionAnalyzer.Repo,
 
 config :prediction_analyzer, start_workers: true
 
+config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -50,7 +50,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
 
   defp compare_vehicle(%Vehicle{label: label, current_status: status} = vehicle, nil) do
     if status == :STOPPED_AT do
-      record_new_stopped_vehicle(vehicle)
+      record_arrival(vehicle)
     end
 
     Logger.info("Tracking new vehicle #{label}")
@@ -119,28 +119,6 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
               "One departure, multiple updates for #{vehicle.label} on #{vehicle.route_id}"
             )
         end
-    end
-
-    nil
-  end
-
-  @spec record_new_stopped_vehicle(Vehicle.t()) :: nil
-  defp record_new_stopped_vehicle(vehicle) do
-    params = vehicle |> vehicle_params()
-
-    %VehicleEvent{}
-    |> VehicleEvent.changeset(params)
-    |> Repo.insert()
-    |> case do
-      {:ok, vehicle_event} ->
-        Logger.info(
-          "Inserted vehicle event: #{vehicle.label} materialized stopped at #{vehicle.stop_id}"
-        )
-
-        associate_vehicle_event_with_predictions(vehicle_event)
-
-      {:error, changeset} ->
-        Logger.warn("Could not insert vehicle event: #{inspect(changeset)}")
     end
 
     nil

--- a/mix.lock
+++ b/mix.lock
@@ -13,7 +13,7 @@
   "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.1", "407d50ac8fc63dfee9175ccb4548e6c5512b5052afa63eedb9cd452a32a91495", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
-  "gettext": {:hex, :gettext, "0.16.0", "4a7e90408cef5f1bf57c5a39e2db8c372a906031cc9b1466e963101cb927dafc", [:mix], [], "hexpm"},
+  "gettext": {:hex, :gettext, "0.17.1", "8baab33482df4907b3eae22f719da492cee3981a26e649b9c2be1c0192616962", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.2", "07e33c794f8f8964ee86cebec1a8ed88db5070e52e904b8f12209773c1036085", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.5", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.4.0", "e0b3c2ad6fa573134e42194d13e925acfa8f89d138bc621ffb7b1989e6d22e73", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
@@ -35,7 +35,7 @@
   "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
-  "timex": {:hex, :timex, "3.4.1", "e63fc1a37453035e534c3febfe9b6b9e18583ec7b37fd9c390efdef97397d70b", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
-  "tzdata": {:hex, :tzdata, "0.5.19", "7962a3997bf06303b7d1772988ede22260f3dae1bf897408ebdac2b4435f4e6a", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
+  "timex": {:hex, :timex, "3.6.1", "efdf56d0e67a6b956cc57774353b0329c8ab7726766a11547e529357ffdc1d56", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5 or ~> 1.0.0", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "1.0.2", "6c4242c93332b8590a7979eaf5e11e77d971e579805c44931207e32aa6ad3db1", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -369,12 +369,13 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
       }
 
       Comparator.compare(new_vehicles, old_vehicles)
+      timestamp = @vehicle.timestamp
 
       assert [
                %VehicleEvent{
                  id: event_id,
                  vehicle_id: "1",
-                 arrival_time: nil,
+                 arrival_time: ^timestamp,
                  departure_time: nil
                }
              ] = Repo.all(from(ve in VehicleEvent, select: ve))
@@ -385,7 +386,7 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
                %VehicleEvent{
                  id: ^event_id,
                  vehicle_id: "1",
-                 arrival_time: nil,
+                 arrival_time: ^timestamp,
                  departure_time: departure_time
                }
              ] = Repo.all(from(ve in VehicleEvent, select: ve))


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📈 Prediction analyzer shouldn't have vehicle events with neither arrival nor departure](https://app.asana.com/0/584764604969369/board)

I updated Timex/tzdata before realizing that actually the timestamps in this issue are in unix time. So actually, the first commit is not necessary, but I figured since it's done, might as well include it... I could always break it off into a separate PR and all that, but it just seemed tedious to do. ;)

Initially we had the helper function `record_arrival`, when we saw a vehicle change from `INCOMING_AT` / `IN_TRANSIT_TO` to `STOPPED_AT`. Then we added `record_new_stopped_vehicle` to handle the case when a vehicle "materialized" out of nowhere, stopped at a station. The only effective difference (aside from logging) between these functions was that the latter did not set the arrival time to the vehicle's timestamp, possibly as an oversight, or possibly because by virtue of it materializing at the stop, we don't technically know when it arrived.

However, now, since we _always_ want an arrival time, I just consolidated down to `record_arrival` for both cases. I don't think the logging differences were important enough to maintain these two separate but identical functions.

~I also added a fallback to `System.system_time(:second)` in case the vehicle's timestamp is `nil`, just to make sure we always have a value for the arrival, but I expect that's a fairly rare occurrence.~ Actually, dialyzer flagged me on this: because of the way we parse and store the data, it's not actually possible to have a nil timestamp after all, so I just removed this fallback from the PR.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
