### PR TITLE
fix: Fix pruning/updating logic to prevent foreign key errors

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,8 @@ config :prediction_analyzer, :api_base_url, "https://api-v3.mbta.com/"
 config :prediction_analyzer, :migration_task, Predictions.ReleaseTasks.NoOp
 config :prediction_analyzer, :stop_name_fetcher, PredictionAnalyzer.StopNameFetcher
 config :prediction_analyzer, :timezone, "America/New_York"
+config :prediction_analyzer, :max_dwell_time_sec, 30 * 60
+config :prediction_analyzer, :prune_lookback_sec, 28 * 24 * 60 * 60
 
 config :prediction_analyzer, PredictionAnalyzer.Repo,
   adapter: Ecto.Adapters.Postgres,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Related to [📈 Prediction analyzer shouldn't have vehicle events with neither arrival nor departure](https://app.asana.com/0/584764604969369/1142290052716497)

#117 addressed an issue where created `vehicle_events` sometimes didn't have an `arrival_time`, meaning it could _also_ not have a `departure_time` if the vehicle changed its ID, went out of service, or was otherwise missed for some reason by Prediction Analyzer. As part of that work, I deleted all the `vehicle_events` with both columns NULL.

However, I've since discovered two more issues. Backing up, it's important to keep in mind the four relevant ways we update the DB:

## Background

1. We create a VehicleEvent when we detect a vehicle has arrived at a station. We set the `arrival_time` to be the vehicle's timestamp (which is generally around the time of creation, so you can think of it roughly as a `created_at` timestamp). We _used_ to set the `arrival_time` as NULL if a vehicle "materializes" stopped at a station. Now we set it to the timestamp as well. It is now impossible for that column to be NULL.

2. We update Predictions immediately after that VehicleEvent is created. We consider all predictions created in the past 30 minutes that don't currently have a `vehicle_event_id`, and assign the `vehicle_event_id` to those rows if they match on vehicle ID and stop ID.

3. We update the VehicleEvent when we detect that the vehicle has departed from a station. We consider all vehicle events with a NULL `departure_time` and an `arrival_time` within the past 30 minutes. Until this PR, we used to also update VehicleEvents with a NULL `arrival_time`. That was **Problem 1**.

4. We prune periodically, deleting all old predictions and vehicle events. Since we failed to set `on delete cascade` when we created the foreign key from predictions to vehicle events, the challenge is to make sure _not_ to delete any vehicle events which a prediction still points to. This was extremely challenging for me to wrap my head around in terms of relative offsets and timing. I believe our pruning logic was **Problem 2**. 

## Problem 1: Updating departures

When we updated departures, `arrival_time > [30 min ago] OR arrival_time is null` logic caused problems. Specifically, we created VehicleEvents with a `null` arrival_time when it materialized at a station. If we missed the departure for some reason, then that particular record was liable to get updated at any point in the future when the same vehicle ID left the same station. I suspect this was actually the cause of a large number of the "multiple departure updates" errors we were seeing (since the next time around would have created a new VehicleEvent for the arrival, and then updated both).

Now that `arrival_time` is always present, I changed the logic to just be `arrival_time > [30 minutes ago]` which should prevent this issue. There's still a chance for the "multiple departure updates" if we miss the departure and the same vehicle comes around and departs within 30 minutes, which I expect might happen on Mattapan occasionally. Here we could discuss matching based on Trip ID rather than Vehicle ID, but then we might have issues with departure predictions from terminals? (We actually _used_ to do it this way, but that was reverted in #48 and I don't remember why, unfortunately...).

I also deleted all the predictions and vehicle events in the DB with NULL arrival_times because the associated departures were unreliable and could have been from _any_ future departure. They only constituted 1-2% of the vehicle events and have already been aggregated (for better or worse) at this point.

## Problem 2: Pruning

I believe the relative timing between the vehicle event and predictions cutoff was wrong before. I drew up a diagram of the situation here: 

![IMG_20191213_084258](https://user-images.githubusercontent.com/384428/70809012-8dcbfa80-1d86-11ea-925f-5014f13cb11e.jpg) 

The key thing is to delete only vehicle events that don't have any predictions pointing to them. The logic we had was delete all the predictions from a download prior to a cutoff. Then delete all the vehicle events from that time _plus_ 30 minutes. On the contrary, we need to be more _conservative_ about VehicleEvent deletions than Predictions, so if anything, it should have been the cutoff _minus_ 30 minutes.

IIRC, I think the 30 minutes came about because that's how long _back_ we look to match a new VehicleEvent with its predictions. On the contrary, we need to worry about how long _after_ a VehicleEvent is created can a prediction point back to it. This is effectively the max dwell time at a station, which by our "update departure" logic is also actually 30 minutes. Note that in the current implementation, if we never detect that a vehicle departs, then its vehicle event will never be associated with any "dwell time" predictions, and so we could use logic something like "delete vehicle events with departure time before cutoff, or null departure time and arrival time before cutoff". However, I don't like relying on that because it's conceivable we could start associating "dwell time predictions" with vehicle events even without a departure.

I updated the Pruner to delete vehicle events with arrival_time < cutoff - max_dwell_time. (Consider the diagram: since predictions can point back to a vehicle event for up to its max dwell time, you have to go further back in time past the cutoff to safely delete the vehicle events.) Since there's a dependency between the "max dwell time" of the Pruner and the "update VehicleEvent departure logic", I pulled it out as an Application config.

There was also confusing logic related to handling NULL, which is simpler now that the `arrival_time` is always present.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
