### PR TITLE
feat: increase nodejs version to 13.x

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 elixir 1.9.1
 erlang 22.1.7
+nodejs 13.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN mix local.hex --force && \
     mix do deps.get --only prod, compile --force
 
 WORKDIR /root/assets/
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - && \
     apt-get install -y nodejs && \
     npm install -g npm@latest  && \
     npm install -g brunch


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

Dependabot bumped the versions of some of our dependencies, but now the deploy is failing due to the fact that we use an old version of nodejs. Let's try bumping the version to see if that works.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
