### PR TITLE
fix: Don't [warn] for expected vehicles without stop IDs

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -153,11 +153,15 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     {:noreply, state}
   end
 
+  @spec parse_vehicles(map(), String.t()) :: [Vehicle.t()]
   defp parse_vehicles(%{"entity" => entities}, environment) do
     Enum.flat_map(entities, fn e ->
       case Vehicle.from_json(e, environment) do
         {:ok, vehicle} ->
           [vehicle]
+
+        :ignore ->
+          []
 
         _ ->
           Logger.warn("failed_to_parse_vehicle_entity #{inspect(e)}")

--- a/lib/prediction_analyzer/vehicle_positions/vehicle.ex
+++ b/lib/prediction_analyzer/vehicle_positions/vehicle.ex
@@ -32,7 +32,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
           timestamp: integer()
         }
 
-  @spec from_json(map(), String.t()) :: {:ok, t()} | :error
+  @spec from_json(map(), String.t()) :: {:ok, t()} | :ignore | :error
   def from_json(
         %{
           "is_deleted" => is_deleted,
@@ -53,24 +53,28 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
         },
         environment
       )
-      when is_boolean(is_deleted) and is_binary(stop_id) and is_binary(route_id) and
+      when is_boolean(is_deleted) and is_binary(route_id) and
              is_binary(trip_id) and is_binary(id) and is_binary(label) and direction_id in [0, 1] and
              current_status in ["INCOMING_AT", "IN_TRANSIT_TO", "STOPPED_AT"] and
              is_integer(timestamp) do
-    vehicle = %__MODULE__{
-      id: id,
-      environment: environment,
-      label: label,
-      is_deleted: is_deleted,
-      trip_id: trip_id,
-      route_id: route_id,
-      direction_id: direction_id,
-      current_status: status_atom(current_status),
-      stop_id: PredictionAnalyzer.Utilities.generic_stop_id(stop_id),
-      timestamp: timestamp
-    }
+    if is_binary(stop_id) do
+      vehicle = %__MODULE__{
+        id: id,
+        environment: environment,
+        label: label,
+        is_deleted: is_deleted,
+        trip_id: trip_id,
+        route_id: route_id,
+        direction_id: direction_id,
+        current_status: status_atom(current_status),
+        stop_id: PredictionAnalyzer.Utilities.generic_stop_id(stop_id),
+        timestamp: timestamp
+      }
 
-    {:ok, vehicle}
+      {:ok, vehicle}
+    else
+      :ignore
+    end
   end
 
   def from_json(_, _) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Don't warn in prediction analyzer when parsing vehicles without stop IDs, which are expected](https://app.asana.com/0/584764604969369/1154516134595690)

I was noticing we had a lot of warnings in our logs from this, but it turns out vehicles without stop IDs are expected from time to time, so we shouldn't warn for them.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
