### PR TITLE
Fix a couple crashes

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -87,6 +87,11 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
 
         {:noreply, state}
 
+      {:ok, %{status_code: code}} ->
+        :ok = Logger.warn(["Could not download subway vehicles. status_code=", inspect(code)])
+
+        {:noreply, state}
+
       {:error, e} ->
         Logger.warn("Could not download subway vehicles; received: #{inspect(e)}")
         {:noreply, state}

--- a/test/prediction_analyzer/weekly_accuracies/aggregator_test.exs
+++ b/test/prediction_analyzer/weekly_accuracies/aggregator_test.exs
@@ -32,30 +32,4 @@ defmodule PredictionAnalyzer.WeeklyAccuracies.AggregatorTest do
 
     assert logs =~ "Finished weekly prediction aggregations"
   end
-
-  test "the :backfill_weekly handle_info runs and logs its results" do
-    Logger.configure(level: :info)
-
-    logs =
-      capture_log(fn ->
-        {:ok, pid} = Aggregator.start_link()
-        Kernel.send(pid, :backfill_weekly)
-      end)
-
-    assert logs =~ "Backfilling weekly data"
-  end
-
-  test "the :backfill_weekly handle_info sets the next backfill time for a week in the past" do
-    backfill_shift =
-      Timex.now()
-      |> Timex.days_to_end_of_week(:sun)
-
-    backfill_time = Timex.shift(Timex.now(), days: backfill_shift - 7)
-
-    {:ok, pid} = Aggregator.start_link(%{backfill_time: backfill_time})
-    Kernel.send(pid, :backfill_weekly)
-    state = :sys.get_state(pid)
-
-    assert Timex.day(state.backfill_time) == backfill_time |> Timex.shift(days: -7) |> Timex.day()
-  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Part of [[extra] prediction analyzer issues ](https://app.asana.com/0/584764604969369/1160105365165145).

When looking through the prediction analyzer logs there have been a few crashes over the last 24 hours:

1. A timeout when running the "weekly aggregation" code, which was trying to fill in the year 1992 when it crashed. This code was just to backfill all the PA data once we added the weekly view. Now that it's done so we no longer need it, so I removed it.
1. A crash when AWS S3 was returning a 500 for some reason. It did this twice in the last 24 hours. I added a clause to our case expression to handle it.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
