### PR TITLE
fix: Handle :ssl_closed and other messages better

### DIFF
--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -98,6 +98,18 @@ defmodule PredictionAnalyzer.Predictions.Download do
     {:noreply, predictions}
   end
 
+  def handle_info({:ssl_closed, _socket}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warn(
+      "PredictionAnalyzer.Predictions.Download event=unexpected_message message=#{inspect(msg)}"
+    )
+
+    {:noreply, state}
+  end
+
   @spec store_subway_predictions(map(), :dev_green | :prod) ::
           {integer(), nil | [term()]} | no_return()
   defp store_subway_predictions(

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -153,8 +153,15 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     {:noreply, state}
   end
 
+  def handle_info({:ssl_closed, _socket}, state) do
+    {:noreply, state}
+  end
+
   def handle_info(msg, state) do
-    Logger.warn("PredictionAnalyzer.VehiclePositions.Tracker unknown_message: #{inspect(msg)}")
+    Logger.warn(
+      "PredictionAnalyzer.VehiclePositions.Tracker event=unknown_message: #{inspect(msg)}"
+    )
+
     {:noreply, state}
   end
 

--- a/test/prediction_analyzer/predictions/download_test.exs
+++ b/test/prediction_analyzer/predictions/download_test.exs
@@ -93,4 +93,38 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
              ]
     end
   end
+
+  describe "Handling messages" do
+    test "ignores :ssl_closed" do
+      {:ok, pid} =
+        Download.start_link(
+          initial_prod_fetch_ms: 10_000,
+          initial_dev_green_fetch_ms: 10_000,
+          initial_commuter_rail_fetch_ms: 10_000
+        )
+
+      log =
+        capture_log(fn ->
+          send(pid, {:ssl_closed, :socket})
+        end)
+
+      refute log =~ "unexpected_message"
+    end
+
+    test "handles but warns about unexpected message" do
+      {:ok, pid} =
+        Download.start_link(
+          initial_prod_fetch_ms: 10_000,
+          initial_dev_green_fetch_ms: 10_000,
+          initial_commuter_rail_fetch_ms: 10_000
+        )
+
+      log =
+        capture_log(fn ->
+          send(pid, :something_unexpected)
+        end)
+
+      assert log =~ "unexpected_message"
+    end
+  end
 end

--- a/test/prediction_analyzer/vehicle_positions/tracker_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/tracker_test.exs
@@ -35,6 +35,17 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
     assert_received({:get, "foo"})
   end
 
+  test "Handles :ssl_closed without a warning" do
+    {:ok, pid} = Tracker.start_link(environment: "dev-green", http_fetcher: NotifyGet)
+
+    log =
+      capture_log(fn ->
+        send(pid, {:ssl_closed, :socket})
+      end)
+
+    refute log =~ "unknown_message"
+  end
+
   describe "handle_info :track_subway_vehicles" do
     test "updates the state with new vehicles" do
       state = %{


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Our old friend `:ssl_closed`. Noticed a bunch of these while querying for warnings and errors in the logs. `Download` was seeing a number of crashes because we weren't handling it, while `Tracker` was simply logging warnings.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
