### PR TITLE
fix: Reduce raw predictions storage to 12 hrs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,7 @@ config :prediction_analyzer, :migration_task, Predictions.ReleaseTasks.NoOp
 config :prediction_analyzer, :stop_name_fetcher, PredictionAnalyzer.StopNameFetcher
 config :prediction_analyzer, :timezone, "America/New_York"
 config :prediction_analyzer, :max_dwell_time_sec, 30 * 60
-config :prediction_analyzer, :prune_lookback_sec, 28 * 24 * 60 * 60
+config :prediction_analyzer, :prune_lookback_sec, 12 * 60 * 60
 
 config :prediction_analyzer, PredictionAnalyzer.Repo,
   adapter: Ecto.Adapters.Postgres,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Related to [📈 Fix prediction analyzer errors once and for all](https://app.asana.com/0/584764604969369/1156002804157851)

Per slack discussion, we don't need to keep so many raw predictions all the time. This bumps it down from 28 days to 12 hours.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
