### PR TITLE
fix: combobox jquery plugin

### DIFF
--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -1,5 +1,5 @@
 import c3 from "c3"
-import jQuery from "jquery"
+import "@danielfarrell/bootstrap-combobox"
 
 interface DataPoint {
   id: number
@@ -214,6 +214,9 @@ const renderDashboard = () => {
 }
 
 const setupDashboard = () => {
+  const comboElement: any = jQuery(".combobox")
+  comboElement.combobox()
+
   const rawData = window.dataPredictionAccuracyJSON
   const prodAccs = rawData.prod_accs
   const showDevGreen = jQuery("#show-dev-green-check").is(":checked")

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -4,6 +4,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const TerserPlugin = require("terser-webpack-plugin")
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin")
 const CopyWebpackPlugin = require("copy-webpack-plugin")
+const { ProvidePlugin } = require("webpack")
 
 module.exports = (env, options) => ({
   resolve: {
@@ -49,6 +50,11 @@ module.exports = (env, options) => ({
   plugins: [
     new MiniCssExtractPlugin({ filename: "../css/app.css" }),
     new CopyWebpackPlugin([{ from: "static/", to: "../" }]),
+    new ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery",
+      "window.jQuery": "jquery",
+    }),
   ],
   devtool: "source-map",
   optimization: {

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -264,9 +264,5 @@
 <% end %>
 
 <script>
-  window.addEventListener("DOMContentLoaded", function() {
-    jQuery('.combobox').combobox();
-  });
-
   window.dataPredictionAccuracyJSON = <%= raw(@chart_data) %>
 </script>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Fix prediction analyzer stop select](https://app.asana.com/0/584764604969369/1174371868398465)

The upgrade to webpack broke our fancy stop selection widget, which was a jquery plugin. Webpack namespaces everything, so the plugin wasn't able to put the `combobox()` method on `$`.

This PR updates the webpack config to make `$` and `jQuery` and `window.jQuery` global like they used to be, which means when we do `import "@danielfarrell/bootstrap-combobox` it modifies the global jQuery object properly (oof, I'm glad we as a development community have moved away from this approach...). I moved the `.combobox()` initialization from a script tag in the phoenix HTML template to our `setupDashboard()` function, where it belongs, in order to import the plugin code.

<img width="422" alt="Screen Shot 2020-05-05 at 3 23 23 PM" src="https://user-images.githubusercontent.com/384428/81112539-6c5ddd80-8ee4-11ea-89f1-cb5163c01d47.png">

It has that little empty box next to the down arrow, but I think we've always had that and that it comes from not including glyphs in our CSS or something like that.

-----

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
