### PR TITLE
fix: filter out predictions where stops_away == nil (aka early departure)

### DIFF
--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -368,6 +368,23 @@ defmodule FakeHTTPoison do
                 "stop_id" => "70063",
                 "stop_sequence" => 30,
                 "stops_away" => 6
+              },
+              %{
+                "arrival" => %{
+                  "delay" => nil,
+                  "time" => 1_540_921_700,
+                  "uncertainty" => nil
+                },
+                "boarding_status" => nil,
+                "departure" => %{
+                  "delay" => nil,
+                  "time" => 1_540_921_745,
+                  "uncertainty" => nil
+                },
+                "schedule_relationship" => "SCHEDULED",
+                "stop_id" => "70063",
+                "stop_sequence" => 40,
+                "stops_away" => nil
               }
             ]
           }

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -133,16 +133,23 @@ defmodule PredictionAnalyzer.Predictions.Download do
         }
 
         if prediction["trip_update"]["stop_time_update"] != nil do
-          Enum.map(prediction["trip_update"]["stop_time_update"], fn update ->
-            Map.merge(trip_prediction, %{
-              arrival_time: update["arrival"]["time"],
-              departure_time: update["departure"]["time"],
-              boarding_status: update["boarding_status"],
-              schedule_relationship: update["schedule_relationship"],
-              stop_id: PredictionAnalyzer.Utilities.generic_stop_id(update["stop_id"]),
-              stop_sequence: update["stop_sequence"],
-              stops_away: update["stops_away"]
-            })
+          Enum.reduce(prediction["trip_update"]["stop_time_update"], [], fn update, acc ->
+            if is_nil(update["stops_away"]) do
+              acc
+            else
+              acc ++
+                [
+                  Map.merge(trip_prediction, %{
+                    arrival_time: update["arrival"]["time"],
+                    departure_time: update["departure"]["time"],
+                    boarding_status: update["boarding_status"],
+                    schedule_relationship: update["schedule_relationship"],
+                    stop_id: PredictionAnalyzer.Utilities.generic_stop_id(update["stop_id"]),
+                    stop_sequence: update["stop_sequence"],
+                    stops_away: update["stops_away"]
+                  })
+                ]
+            end
           end)
         end
       end)


### PR DESCRIPTION
Similar to https://github.com/mbta/realtime_signs/pull/385/, filtering out predictions where `stops_away == nil` as this is how we distinguish predictions saved for early departures.
