### PR TITLE
feat: add multi-select and groups to stop filter

### DIFF
--- a/assets/css/analyzer.scss
+++ b/assets/css/analyzer.scss
@@ -121,6 +121,18 @@
 .reminder-text {
   display: none;
 }
+
 .reminder-text:target {
   display: block;
+}
+
+/* Selectize: decouple dropdown width from input width */
+
+.selectize-dropdown {
+  width: auto !important;
+}
+
+.selectize-dropdown [data-selectable],
+.selectize-dropdown .optgroup-header {
+  white-space: nowrap;
 }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -59,11 +59,6 @@
         }
       }
     },
-    "@danielfarrell/bootstrap-combobox": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@danielfarrell/bootstrap-combobox/-/bootstrap-combobox-1.1.8.tgz",
-      "integrity": "sha1-SJ0KnttaL8nGWXHUQiKU56uTIOw="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -374,6 +369,12 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
+      "dev": true
+    },
+    "@types/selectize": {
+      "version": "0.12.34",
+      "resolved": "https://registry.npmjs.org/@types/selectize/-/selectize-0.12.34.tgz",
+      "integrity": "sha512-OAXHsgsHBMJBHnB6QrFlHVa0+gCE5lgjdpwJDlJLRhrcsM4I2VXrm2vsG00//Rpdm4XgnX17vrBpjHlWOk1ALw==",
       "dev": true
     },
     "@types/sizzle": {
@@ -811,6 +812,11 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+    },
     "anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -956,6 +962,14 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-each": {
       "version": "1.0.3",
@@ -1432,6 +1446,15 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001141.tgz",
       "integrity": "sha512-EHfInJHoQTmlMdVZrEc5gmwPc0zyN/hVufmGHPbVNQwlk7tJfCmQ2ysRZMY2MeleBivALUTyyxXnQjK18XrVpA==",
       "dev": true
+    },
+    "cardinal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
+      "requires": {
+        "ansicolors": "~0.2.1",
+        "redeyed": "~1.0.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -2234,6 +2257,11 @@
           "dev": true
         }
       }
+    },
+    "csv-parse": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.12.0.tgz",
+      "integrity": "sha512-wPQl3H79vWLPI8cgKFcQXl0NBgYYEqVnT1i6/So7OjMpsI540oD7p93r3w6fDSyPvwkTepG05F69/7AViX2lXg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4045,6 +4073,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "humanize": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
+      "integrity": "sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4740,8 +4773,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -4878,6 +4910,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
       }
+    },
+    "microplugin": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/microplugin/-/microplugin-0.0.3.tgz",
+      "integrity": "sha1-H8Lhu3yeGegr2Eu6kTe75xJQ2M0="
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -5449,6 +5486,22 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        }
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -6609,6 +6662,21 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "redeyed": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+      "requires": {
+        "esprima": "~3.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
+        }
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6946,6 +7014,15 @@
         }
       }
     },
+    "selectize": {
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/selectize/-/selectize-0.12.6.tgz",
+      "integrity": "sha512-bWO5A7G+I8+QXyjLfQUgh31VI4WKYagUZQxAXlDyUmDDNrFxrASV0W9hxCOl0XJ/XQ1dZEu3G9HjXV4Wj0yb6w==",
+      "requires": {
+        "microplugin": "0.0.3",
+        "sifter": "^0.5.1"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -7037,6 +7114,18 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "sifter": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/sifter/-/sifter-0.5.4.tgz",
+      "integrity": "sha512-t2yxTi/MM/ESup7XH5oMu8PUcttlekt269RqxARgnvS+7D/oP6RyA1x3M/5w8dG9OgkOyQ8hNRWelQ8Rj4TAQQ==",
+      "requires": {
+        "async": "^2.6.0",
+        "cardinal": "^1.0.0",
+        "csv-parse": "^4.6.5",
+        "humanize": "^0.0.9",
+        "optimist": "^0.6.1"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -9049,6 +9138,11 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,15 +11,16 @@
     "check": "tsc --noEmit && npm run lint:check && npm run format:check"
   },
   "dependencies": {
-    "@danielfarrell/bootstrap-combobox": "^1.1.8",
     "@types/c3": "^0.7.4",
     "@types/jquery": "^3.5.1",
     "c3": "^0.7.20",
     "jquery": "^3.5.1",
     "phoenix": "file:../deps/phoenix",
-    "phoenix_html": "file:../deps/phoenix_html"
+    "phoenix_html": "file:../deps/phoenix_html",
+    "selectize": "^0.12.4"
   },
   "devDependencies": {
+    "@types/selectize": "^0.12.34",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/eslint-plugin-tslint": "^3.10.1",
     "@typescript-eslint/parser": "^2.34.0",

--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -1,5 +1,6 @@
 import c3 from "c3"
-import "@danielfarrell/bootstrap-combobox"
+import "selectize/dist/js/standalone/selectize.js"
+import "selectize/dist/css/selectize.bootstrap3.css"
 
 interface DataPoint {
   id: number
@@ -204,8 +205,11 @@ const renderDashboard = () => {
 }
 
 const setupDashboard = () => {
-  const comboElement: any = jQuery(".combobox")
-  comboElement.combobox()
+  jQuery("#filters_stop_ids").selectize({
+    dropdownParent: "body",
+    placeholder: "Type to search...",
+    scrollDuration: 0,
+  })
 
   const rawData = window.dataPredictionAccuracyJSON
   const prodAccs = rawData.prod_accs

--- a/lib/prediction_analyzer/filters/stop_groups.ex
+++ b/lib/prediction_analyzer/filters/stop_groups.ex
@@ -1,0 +1,51 @@
+defmodule PredictionAnalyzer.Filters.StopGroups do
+  @red_trunk ~w(70061 70063 70064 70065 70066 70067 70068 70069 70070 70071 70072 70073 70074 70075 70076 70077 70078 70079 70080 70081 70082 70083 70084)
+  @ashmont_branch ~w(70085 70086 70087 70088 70089 70090 70091 70092 70093 70094)
+  @braintree_branch ~w(70095 70096 70097 70098 70099 70100 70101 70102 70103 70104 70105)
+
+  # GLX note: these do not include Science Park or Lechmere
+  @green_trunk ~w(70150 70151 70152 70153 70154 70155 70156 70157 70158 70159 70196 70197 70198 70199 70200 70201 70202 70203 70204 70205 70206 71150 71151 71199)
+  @b_branch ~w(70106 70107 70110 70111 70112 70113 70114 70115 70116 70117 70120 70121 70124 70125 70126 70127 70128 70129 70130 70131 70134 70135 70136 70137 70138 70139 70140 70141 70142 70143 70144 70145 70146 70147 70148 70149)
+  @c_branch ~w(70211 70212 70213 70214 70215 70216 70217 70218 70219 70220 70223 70224 70225 70226 70227 70228 70229 70230 70231 70232 70233 70234 70235 70236 70237 70238)
+  @d_branch ~w(70160 70161 70162 70163 70164 70165 70166 70167 70168 70169 70170 70171 70172 70173 70174 70175 70176 70177 70178 70179 70180 70181 70182 70183 70186 70187)
+  @e_branch ~w(70239 70240 70241 70242 70243 70244 70245 70246 70247 70248 70249 70250 70251 70252 70253 70254 70255 70256 70257 70258 70260)
+  @terminals ~w(70001 70036 70038 70059 70060 70061 70093 70094 70105 70106 70107 70160 70161 70196 70197 70198 70199 70201 70202 70205 70206 70237 70238 70260 70261 70275 70276 70838 71199)
+
+  # Terminal departure platforms + away-from-terminal platforms up to 3 stops away. Note: 70001,
+  # 70036, 70061, 70105, 70260, and 70261 include all platforms at the stop, since these terminals
+  # do not have static arrival/departure platforms.
+  @near_terminals_map %{
+    blue: ~w(70038 70040 70042 70044 70053 70055 70057 70059),
+    green_b: ~w(70106 70110 70112 70114),
+    green_c: ~w(70232 70234 70236 70238),
+    green_d: ~w(70160 70162 70164 70166),
+    green_e: ~w(70260 70254 70256 70258),
+    green_trunk: ~w(70155 70157 70159 70196 70197 70198 70199 70202 70204 70206),
+    mattapan: ~w(70261 70263 70265 70267 70270 70272 70274 70276),
+    orange: ~w(70001 70003 70005 70007 70032 70034 70036 70278),
+    red_ashmont: ~w(70088 70090 70092 70094),
+    red_braintree: ~w(70100 70102 70104 70105),
+    red_trunk: ~w(70061 70063 70065 70067)
+  }
+  @near_terminals Map.values(@near_terminals_map) |> List.flatten()
+
+  @groups [
+    {"_trunk", "Trunk stops", @red_trunk ++ @green_trunk},
+    {"_branch", "Branch stops",
+     @ashmont_branch ++ @braintree_branch ++ @b_branch ++ @c_branch ++ @d_branch ++ @e_branch},
+    {"_terminal", "Terminals", @terminals},
+    {"_near_terminal", "Terminals + next 3 stops", @near_terminals},
+    {"_ashmont_branch", "Red Line - Ashmont branch", @ashmont_branch},
+    {"_braintree_branch", "Red Line - Braintree branch", @braintree_branch}
+  ]
+
+  @mappings Enum.map(@groups, fn {id, _name, stop_ids} -> {id, stop_ids} end) |> Enum.into(%{})
+
+  @spec expand_groups([String.t()]) :: [String.t()]
+  def expand_groups(stop_or_group_ids) do
+    Enum.flat_map(stop_or_group_ids, fn id -> Map.get(@mappings, id, [id]) end)
+  end
+
+  @spec group_names() :: [{atom(), String.t()}]
+  def group_names, do: Enum.map(@groups, fn {id, name, _stop_ids} -> {name, id} end)
+end

--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -45,7 +45,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
     q = from(acc in __MODULE__, [])
 
     with {:ok, q} <- filter_by_route(q, params["route_ids"]),
-         {:ok, q} <- filter_by_stop(q, params["stop_id"]),
+         {:ok, q} <- filter_by_stop(q, params["stop_ids"]),
          {:ok, q} <- filter_by_direction(q, params["direction_id"]),
          {:ok, q} <- filter_by_arrival_departure(q, params["arrival_departure"]),
          {:ok, q} <- filter_by_bin(q, params["bin"]),

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -13,7 +13,6 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
           "filters" =>
             %{
               "route_ids" => route_ids,
-              "stop_id" => stop_id,
               "direction_id" => direction_id,
               "arrival_departure" => arrival_departure,
               "bin" => bin,
@@ -21,7 +20,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
             } = filter_params
         } = params
       )
-      when not is_nil(route_ids) and not is_nil(stop_id) and not is_nil(direction_id) and
+      when not is_nil(route_ids) and not is_nil(direction_id) and
              byte_size(arrival_departure) > 0 and byte_size(bin) > 0 do
     mode_atom = PredictionAnalyzer.Utilities.string_to_mode(mode)
     routes = PredictionAnalyzer.Utilities.routes_for_mode(mode_atom)
@@ -132,7 +131,6 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
 
     default_filters = %{
       "route_ids" => "",
-      "stop_id" => "",
       "direction_id" => "any",
       "arrival_departure" => "all",
       "bin" => "All",

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -123,8 +123,8 @@
 
         <%= if f.params["chart_range"] != "By Station" do %>
           <div class="form-group">
-            <%= label(f, :stop_id, "Stop ID") %>
-            <%= select(f, :stop_id, stop_descriptions(@mode), class: 'combobox form-control') %>
+            <%= label(f, :stop_ids, "Stops") %>
+            <%= multiple_select(f, :stop_ids, stop_filter_options(@mode), class: 'form-control') %>
           </div>
         <% end %>
 

--- a/test/prediction_analyzer/filters/stop_groups_test.exs
+++ b/test/prediction_analyzer/filters/stop_groups_test.exs
@@ -1,0 +1,17 @@
+defmodule PredictionAnalyzer.Filters.StopGroupsTest do
+  use ExUnit.Case, async: true
+  alias PredictionAnalyzer.Filters.StopGroups
+
+  describe "expand_groups/1" do
+    test "replaces stop group IDs in a list with the matching set of stop IDs" do
+      assert StopGroups.expand_groups(~w(stop1 _ashmont_branch stop2)) ==
+               ~w(stop1 70085 70086 70087 70088 70089 70090 70091 70092 70093 70094 stop2)
+    end
+  end
+
+  describe "group_names/0" do
+    test "returns a list of group IDs and their friendly names" do
+      assert StopGroups.group_names() |> hd() == {"Trunk stops", "_trunk"}
+    end
+  end
+end

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -93,7 +93,6 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
              "filters[chart_range]" => "Hourly",
              "filters[service_date]" => @today_str,
              "filters[route_ids]" => "",
-             "filters[stop_id]" => "",
              "filters[direction_id]" => "any",
              "filters[arrival_departure]" => "all",
              "filters[bin]" => "All",
@@ -150,7 +149,6 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
           "chart_range" => "Daily",
           "date_start" => "2019-01-01",
           "route_ids" => "",
-          "stop_id" => "",
           "direction_id" => "any",
           "arrival_departure" => "all",
           "bin" => "All"
@@ -186,7 +184,6 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
       get(conn, "/accuracy", %{
         "filters" => %{
           "route_ids" => "",
-          "stop_id" => "",
           "direction_id" => "any",
           "arrival_departure" => "all",
           "bin" => "All",
@@ -223,7 +220,6 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
           "date_end" => "invalid",
           "route_ids" => "",
           "mode" => "subway",
-          "stop_id" => "",
           "direction_id" => "any",
           "arrival_departure" => "all",
           "bin" => "All"

--- a/test/prediction_analyzer_web/views/accuracy_view_test.exs
+++ b/test/prediction_analyzer_web/views/accuracy_view_test.exs
@@ -82,18 +82,16 @@ defmodule PredictionAnalyzerWeb.AccuracyViewTest do
            })
   end
 
-  describe "stop_descriptions/1" do
-    test "returns subway stops" do
-      assert AccuracyView.stop_descriptions(:subway) == [
-               {"", ""},
-               {"Jane Roe St (67890)", "67890"},
-               {"John Doe Square (12345)", "12345"}
-             ]
+  describe "stop_filter_options/1" do
+    test "returns subway stops and groups" do
+      assert %{
+               "Groups" => [{"Trunk stops", "_trunk"} | _],
+               "Stops" => [{"Jane Roe St (67890)", "67890"}, {"John Doe Square (12345)", "12345"}]
+             } = AccuracyView.stop_filter_options(:subway)
     end
 
     test "returns commuter rail stops" do
-      assert AccuracyView.stop_descriptions(:commuter_rail) == [
-               {"", ""},
+      assert AccuracyView.stop_filter_options(:commuter_rail) == [
                {"No Description Stop", "No Description Stop"}
              ]
     end


### PR DESCRIPTION
The stop filter is now a `<select multiple>` and has the conventional behavior for submitting multiple values for the same form field, i.e. the URL is `filters[stop_ids][]=70001&filters[stop_ids][]=...` rather than `filters[stop_id]=70001`.

Our existing `bootstrap-combobox` library didn't support multi-select, so this swaps it out for Selectize. Unfortunately this library is not actively maintained (last release in 2006), but it is otherwise stable and one of the few that doesn't require React/Vue/etc., works correctly out of the box with our Webpack/jQuery/Bootstrap setup, and has search ranking (i.e. typing "Wonderland" puts the station itself at the top, above all the stops that have "Wonderland" elsewhere in their name and would be sorted above it alphabetically).

To avoid creating very long URLs, stop groups are implemented as single "special values" (such as `_terminal`) on the client side, which the server translates into a set of stop IDs. For now these are hard-coded.

**Asana Ticket:** [📈 add stop groupings to analyzer](https://app.asana.com/0/584764604969369/1120764604279515)

![Screen-Recording-2020-10-21-at-3](https://user-images.githubusercontent.com/394835/96776061-79995680-13b6-11eb-82bc-71d82f6e05a4.gif)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
