### PR TITLE
Improve matching of vehicle events, other small fixes

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -67,12 +67,6 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
       |> vehicle_params()
       |> Map.put(:arrival_time, vehicle.timestamp)
 
-    Logger.info(
-      "ml_datapoint vehicle_id=#{params.vehicle_id} trip_id=#{params.trip_id} event_type=arrival stop_id=#{
-        params.stop_id
-      } time=#{params.arrival_time}"
-    )
-
     %VehicleEvent{}
     |> VehicleEvent.changeset(params)
     |> Repo.insert()
@@ -142,12 +136,6 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
 
   @spec associate_vehicle_event_with_predictions(VehicleEvent.t()) :: nil
   defp associate_vehicle_event_with_predictions(vehicle_event) do
-    Logger.info(
-      "ml_datapoint vehicle_id=#{vehicle_event.vehicle_id} trip_id=#{vehicle_event.trip_id} event_type=departure stop_id=#{
-        vehicle_event.stop_id
-      } time=#{vehicle_event.departure_time}"
-    )
-
     from(
       p in Prediction,
       where:

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -95,7 +95,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     from(
       ve in VehicleEvent,
       where:
-        ve.environment == ^vehicle.environment and ve.trip_id == ^vehicle.trip_id and
+        ve.environment == ^vehicle.environment and ve.vehicle_id == ^vehicle.id and
           ve.stop_id == ^vehicle.stop_id and is_nil(ve.departure_time) and
           ve.arrival_time > ^(System.system_time(:second) - max_dwell_time_sec),
       update: [set: [departure_time: ^vehicle.timestamp]]

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -25,7 +25,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
       )
 
     aws_vehicle_positions_url =
-      get_env_vehicle_positions_url(environment) || args[:aws_vehicle_positions_url]
+      args[:aws_vehicle_positions_url] || get_env_vehicle_positions_url(environment)
 
     http_fetcher =
       Keyword.get(args, :http_fetcher, Application.get_env(:prediction_analyzer, :http_fetcher))

--- a/test/prediction_analyzer/vehicle_positions/comparator_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/comparator_test.exs
@@ -44,7 +44,6 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
 
   describe "compare_vehicles" do
     test "records arrival and departure of vehicle" do
-      Logger.configure(level: :info)
       assert Repo.one(from(ve in VehicleEvent, select: count(ve.id))) == 0
 
       old_vehicles = %{
@@ -55,53 +54,45 @@ defmodule PredictionAnalyzer.VehiclePositions.ComparatorTest do
         "1" => %{@vehicle | current_status: :STOPPED_AT}
       }
 
-      log =
-        capture_log([level: :info], fn ->
-          Comparator.compare(new_vehicles, old_vehicles)
+      Comparator.compare(new_vehicles, old_vehicles)
 
-          arrival_time = @vehicle.timestamp
+      arrival_time = @vehicle.timestamp
 
-          vehicle_events = Repo.all(from(ve in VehicleEvent, select: ve))
+      vehicle_events = Repo.all(from(ve in VehicleEvent, select: ve))
 
-          assert [
-                   %VehicleEvent{
-                     vehicle_id: "1",
-                     arrival_time: ^arrival_time,
-                     departure_time: nil
-                   }
-                 ] = vehicle_events
+      assert [
+               %VehicleEvent{
+                 vehicle_id: "1",
+                 arrival_time: ^arrival_time,
+                 departure_time: nil
+               }
+             ] = vehicle_events
 
-          ve_id = List.first(vehicle_events).id
+      ve_id = List.first(vehicle_events).id
 
-          departure_time = arrival_time + 30
+      departure_time = arrival_time + 30
 
-          old_vehicles = new_vehicles
+      old_vehicles = new_vehicles
 
-          new_vehicles = %{
-            "1" => %{
-              @vehicle
-              | current_status: :IN_TRANSIT_TO,
-                stop_id: "stop2",
-                timestamp: departure_time
-            }
-          }
+      new_vehicles = %{
+        "1" => %{
+          @vehicle
+          | current_status: :IN_TRANSIT_TO,
+            stop_id: "stop2",
+            timestamp: departure_time
+        }
+      }
 
-          Comparator.compare(new_vehicles, old_vehicles)
+      Comparator.compare(new_vehicles, old_vehicles)
 
-          assert [
-                   %VehicleEvent{
-                     id: ^ve_id,
-                     vehicle_id: "1",
-                     arrival_time: ^arrival_time,
-                     departure_time: ^departure_time
-                   }
-                 ] = Repo.all(from(ve in VehicleEvent, select: ve))
-        end)
-
-      assert log =~ "ml_datapoint"
-      assert log =~ "event_type=arrival"
-      assert log =~ "event_type=departure"
-      Logger.configure(level: :warn)
+      assert [
+               %VehicleEvent{
+                 id: ^ve_id,
+                 vehicle_id: "1",
+                 arrival_time: ^arrival_time,
+                 departure_time: ^departure_time
+               }
+             ] = Repo.all(from(ve in VehicleEvent, select: ve))
     end
 
     test "logs an error when there are multiple updates for a subway vehicle" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📈 investigate: improving handling of times](https://app.asana.com/0/584764604969369/1196078640623588/f)

Previously, when recording the arrival time of a vehicle event, we would match based on the trip ID of the vehicle. However, if this changed mid-route, we could get artificially penalized.

A [followup ticket](https://app.asana.com/0/881264583703207/1198881667597053/f) was created for the more involved changes to how aggregation works, since it might change things in ways that makes it hard to compare future data to past data.

There are a couple of other small commits in here fixing other things as well, see full commit messages for details.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
