### PR TITLE
perf: adjust database indexes for usage patterns

### DIFF
--- a/priv/repo/migrations/20201022151038_adjust_indexes.exs
+++ b/priv/repo/migrations/20201022151038_adjust_indexes.exs
@@ -1,0 +1,22 @@
+defmodule PredictionAnalyzer.Repo.Migrations.AdjustIndexes do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+  def change do
+    drop(index(:predictions, :trip_id, where: "vehicle_event_id IS NULL", concurrently: true))
+    drop(index(:predictions, :vehicle_id, concurrently: true))
+    create(index(:vehicle_events, :stop_id, where: "departure_time IS NULL", concurrently: true))
+
+    create(
+      index(:vehicle_events, :vehicle_id, where: "departure_time IS NULL", concurrently: true)
+    )
+
+    create(index(:predictions, :stop_id, where: "vehicle_event_id IS NULL", concurrently: true))
+
+    create(
+      index(:predictions, :vehicle_id, where: "vehicle_event_id IS NULL", concurrently: true)
+    )
+
+    create(index(:prediction_accuracy, :stop_id, concurrently: true))
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -246,6 +246,13 @@ CREATE INDEX prediction_accuracy_service_date_index ON public.prediction_accurac
 
 
 --
+-- Name: prediction_accuracy_stop_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX prediction_accuracy_stop_id_index ON public.prediction_accuracy USING btree (stop_id);
+
+
+--
 -- Name: predictions_file_timestamp_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -253,10 +260,10 @@ CREATE INDEX predictions_file_timestamp_index ON public.predictions USING btree 
 
 
 --
--- Name: predictions_trip_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: predictions_stop_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX predictions_trip_id_index ON public.predictions USING btree (trip_id) WHERE (vehicle_event_id IS NULL);
+CREATE INDEX predictions_stop_id_index ON public.predictions USING btree (stop_id) WHERE (vehicle_event_id IS NULL);
 
 
 --
@@ -270,7 +277,7 @@ CREATE INDEX predictions_vehicle_event_id_index ON public.predictions USING btre
 -- Name: predictions_vehicle_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX predictions_vehicle_id_index ON public.predictions USING btree (vehicle_id);
+CREATE INDEX predictions_vehicle_id_index ON public.predictions USING btree (vehicle_id) WHERE (vehicle_event_id IS NULL);
 
 
 --
@@ -288,6 +295,20 @@ CREATE INDEX vehicle_events_departure_time_index ON public.vehicle_events USING 
 
 
 --
+-- Name: vehicle_events_stop_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX vehicle_events_stop_id_index ON public.vehicle_events USING btree (stop_id) WHERE (departure_time IS NULL);
+
+
+--
+-- Name: vehicle_events_vehicle_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX vehicle_events_vehicle_id_index ON public.vehicle_events USING btree (vehicle_id) WHERE (departure_time IS NULL);
+
+
+--
 -- Name: predictions predictions_vehicle_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -299,5 +320,5 @@ ALTER TABLE ONLY public.predictions
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO public."schema_migrations" (version) VALUES (20181017190602), (20181022210113), (20181025152446), (20181026133153), (20181026135330), (20181026160237), (20181029181739), (20181029192143), (20181029203022), (20181106155014), (20181112161231), (20181130203837), (20181203152039), (20190114210649), (20190315155432), (20190528184413), (20190624192925), (20190701174220), (20201019175956);
+INSERT INTO public."schema_migrations" (version) VALUES (20181017190602), (20181022210113), (20181025152446), (20181026133153), (20181026135330), (20181026160237), (20181029181739), (20181029192143), (20181029203022), (20181106155014), (20181112161231), (20181130203837), (20181203152039), (20190114210649), (20190315155432), (20190528184413), (20190624192925), (20190701174220), (20201019175956), (20201022151038);
 


### PR DESCRIPTION
**Asana Ticket:** [📈 improve indexes and matching queries](https://app.asana.com/0/584764604969369/1195680449065004)

This makes the following index changes:

* Drop `trip_id` on `predictions`, since this index is seemingly unused (both in the code and as indicated by Postgres stats), and is taking up ~11GB of space that could be reclaimed.

* Add `stop_id` on `predictions`, since this column is queried in the process of associating vehicle events with predictions. The index is partial on rows where `vehicle_event_id IS NULL`, since this condition is always included in the queries that include `stop_id`. This should save a bit of space since the condition is only true for half the rows in the current production database (the now-dropped `trip_id` index did the same thing).

* Replace `vehicle_id` on `predictions` with a partial index having the same condition as the above, for the same reason.

* Add `stop_id` and `vehicle_id` on `vehicle_events`, partial on rows where `departure_time IS NULL`, since these columns are queried when filling in departure times.

* Add `stop_id` on `prediction_accuracy`, since filtering on this field is part of the frontend's regular operation.

Also considered but *not* implemented were indexes on `predictions` for `route_id`, and on `prediction_accuracy` for `route_id` and `bin`. While we do query on these fields often, it's always in combination with at least one other indexed field; and since there are only a few distinct routes and bins, the index likely wouldn't narrow the result set enough to justify its use (to the query planner, if not to us).

### Notes

We drop and create all indexes concurrently, which enables the app to continue querying and updating the tables being indexed, at the cost of making the indexing itself slower. Each `CREATE/DROP INDEX` statement still blocks until the index is created/dropped, but the migrate-on-startup behavior runs the migrations inside a `spawn/1`, so this should not prevent the app from starting up. Unfortunately it does mean if the app instance running the migration goes down for whatever reason, the migration state (and maybe the index state) will be left inconsistent, since concurrent index operations can't be done in a transaction. The impact is just that it will take some extra work to clean it up manually — the app should continue to function in any case.

### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
