### PR TITLE
chore: extend prune lookback period to keep 7 days of predictions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,7 @@ config :prediction_analyzer, :migration_task, Predictions.ReleaseTasks.NoOp
 config :prediction_analyzer, :stop_name_fetcher, PredictionAnalyzer.StopNameFetcher
 config :prediction_analyzer, :timezone, "America/New_York"
 config :prediction_analyzer, :max_dwell_time_sec, 30 * 60
-config :prediction_analyzer, :prune_lookback_sec, 12 * 60 * 60
+config :prediction_analyzer, :prune_lookback_sec, 7 * 24 * 60 * 60
 
 config :prediction_analyzer, PredictionAnalyzer.Repo, adapter: Ecto.Adapters.Postgres
 

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -9,6 +9,8 @@ defmodule PredictionAnalyzer.Pruner do
 
   require Logger
 
+  @prune_interval_ms 6 * 60 * 60 * 1_000
+
   def start_link(_args) do
     GenServer.start_link(__MODULE__, [])
   end
@@ -58,6 +60,6 @@ defmodule PredictionAnalyzer.Pruner do
 
   @spec schedule_next_run(pid()) :: reference()
   defp schedule_next_run(pid) do
-    Process.send_after(pid, :prune, 12 * 60 * 60 * 1_000)
+    Process.send_after(pid, :prune, @prune_interval_ms)
   end
 end

--- a/test/prediction_analyzer/pruner_test.exs
+++ b/test/prediction_analyzer/pruner_test.exs
@@ -48,7 +48,7 @@ defmodule PredictionAnalyzer.PrunerTest do
     assert Process.alive?(pid)
   end
 
-  test "prune deletes predictions that are older than 28 days old with dwell time grace period for vehicle events" do
+  test "prune deletes predictions that are older than lookback period with dwell time grace period for vehicle events" do
     max_dwell_time_sec = Application.get_env(:prediction_analyzer, :max_dwell_time_sec)
     prune_lookback_sec = Application.get_env(:prediction_analyzer, :prune_lookback_sec)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📈 capture raw predictions for 1 week](https://app.asana.com/0/584764604969369/1195680449065006/f)

Updated the prune lookback as specified. Per the ticket the pruning should run at least as frequently if not more so, so I doubled it to once every 6 hours instead of once every 12 hours. Looking at recent logs, we haven't come close to hitting our pruning timeout threshold, so I think this should be pretty safe.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
