### PR TITLE
feat: track and filter by kind of prediction

### DIFF
--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -210,6 +210,11 @@ const setupDashboard = () => {
     placeholder: "Type to search...",
     scrollDuration: 0,
   })
+  jQuery("#filters_kinds").selectize({
+    dropdownParent: "body",
+    placeholder: "(all kinds)",
+    scrollDuration: 0,
+  })
 
   const rawData = window.dataPredictionAccuracyJSON
   const prodAccs = rawData.prod_accs

--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -345,7 +345,7 @@ defmodule FakeHTTPoison do
                 "departure" => %{
                   "delay" => nil,
                   "time" => 1_540_921_502,
-                  "uncertainty" => nil
+                  "uncertainty" => 60
                 },
                 "schedule_relationship" => "SCHEDULED",
                 "stop_id" => "Alewife-01",
@@ -356,13 +356,13 @@ defmodule FakeHTTPoison do
                 "arrival" => %{
                   "delay" => nil,
                   "time" => 1_540_921_600,
-                  "uncertainty" => nil
+                  "uncertainty" => 60
                 },
                 "boarding_status" => nil,
                 "departure" => %{
                   "delay" => nil,
                   "time" => 1_540_921_645,
-                  "uncertainty" => nil
+                  "uncertainty" => 60
                 },
                 "schedule_relationship" => "SCHEDULED",
                 "stop_id" => "70063",
@@ -373,13 +373,13 @@ defmodule FakeHTTPoison do
                 "arrival" => %{
                   "delay" => nil,
                   "time" => 1_540_921_700,
-                  "uncertainty" => nil
+                  "uncertainty" => 60
                 },
                 "boarding_status" => nil,
                 "departure" => %{
                   "delay" => nil,
                   "time" => 1_540_921_745,
-                  "uncertainty" => nil
+                  "uncertainty" => 60
                 },
                 "schedule_relationship" => "SCHEDULED",
                 "stop_id" => "70063",

--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -13,6 +13,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
     field(:route_id, :string)
     field(:direction_id, :integer)
     field(:arrival_departure, :string)
+    field(:kind, :string)
     field(:bin, :string)
     field(:num_predictions, :integer)
     field(:num_accurate_predictions, :integer)
@@ -28,6 +29,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
       :route_id,
       :direction_id,
       :arrival_departure,
+      :kind,
       :bin,
       :num_predictions,
       :num_accurate_predictions
@@ -35,8 +37,9 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
 
     %__MODULE__{}
     |> cast(params, all_fields)
-    |> validate_required(all_fields)
+    |> validate_required(all_fields -- [:kind])
     |> validate_inclusion(:arrival_departure, ["arrival", "departure"])
+    |> validate_inclusion(:kind, Map.values(kinds()))
     |> validate_inclusion(:bin, Map.keys(bins()))
   end
 
@@ -49,6 +52,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
          {:ok, q} <- filter_by_direction(q, params["direction_id"]),
          {:ok, q} <- filter_by_arrival_departure(q, params["arrival_departure"]),
          {:ok, q} <- filter_by_bin(q, params["bin"]),
+         {:ok, q} <- filter_by_kind(q, params["kinds"]),
          {:ok, q} <- filter_by_mode(q, params["mode"]),
          {:ok, q} <-
            filter_by_timeframe(

--- a/lib/prediction_analyzer/prediction_accuracy/query.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/query.ex
@@ -9,6 +9,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
           DateTime.t(),
           String.t(),
           String.t(),
+          String.t(),
           integer(),
           integer(),
           integer(),
@@ -19,6 +20,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         repo_module,
         current_time,
         arrival_departure,
+        kind,
         bin_name,
         bin_min,
         bin_max,
@@ -44,7 +46,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
       bin_error_max,
       min_unix,
       max_unix,
-      environment
+      environment,
+      kind
     ])
   end
 
@@ -66,6 +69,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         direction_id,
         arrival_departure,
         bin,
+        kind,
         num_predictions,
         num_accurate_predictions,
         mean_error,
@@ -80,6 +84,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         p.direction_id AS direction_id,
         $3 AS arrival_departure,
         $4 AS bin,
+        $12 AS kind,
         COUNT(*) AS num_predictions,
         SUM(
           CASE
@@ -100,6 +105,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
       WHERE p.file_timestamp > $9
         AND p.file_timestamp < $10
         AND p.environment = $11
+        AND p.kind = $12
         AND p.#{arrival_or_departure_time_column} IS NOT NULL
         AND p.#{arrival_or_departure_time_column} > p.file_timestamp
         AND p.#{arrival_or_departure_time_column} - p.file_timestamp >= $5

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -2,7 +2,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
   use GenServer
 
   require Logger
-  alias PredictionAnalyzer.Predictions.Prediction
+  alias PredictionAnalyzer.{Filters, Predictions.Prediction}
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, opts)
@@ -143,6 +143,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
                     arrival_time: update["arrival"]["time"],
                     departure_time: update["departure"]["time"],
                     boarding_status: update["boarding_status"],
+                    kind: kind_from_stop_time_update(update),
                     schedule_relationship: update["schedule_relationship"],
                     stop_id: PredictionAnalyzer.Utilities.generic_stop_id(update["stop_id"]),
                     stop_sequence: update["stop_sequence"],
@@ -159,6 +160,11 @@ defmodule PredictionAnalyzer.Predictions.Download do
 
   defp store_subway_predictions(_, _) do
     nil
+  end
+
+  @spec kind_from_stop_time_update(%{String.t() => any()}) :: nil | String.t()
+  defp kind_from_stop_time_update(%{"arrival" => arrival, "departure" => departure}) do
+    Filters.kinds() |> Map.get(arrival["uncertainty"] || departure["uncertainty"])
   end
 
   defp store_commuter_rail_predictions(%{"data" => data}, last_modified) do

--- a/lib/prediction_analyzer/predictions/prediction.ex
+++ b/lib/prediction_analyzer/predictions/prediction.ex
@@ -18,6 +18,7 @@ defmodule PredictionAnalyzer.Predictions.Prediction do
     field(:stop_sequence, :integer)
     field(:stops_away, :integer)
     field(:direction_id, :integer)
+    field(:kind, :string)
     belongs_to(:vehicle_event, VehicleEvent)
   end
 end

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -116,10 +116,10 @@
           </div>
         <% end %>
 
-	<div class="form-group">
-	    <%= label(f, :route_ids, "Route") %>
-	    <%= select(f, :route_ids, route_options(@mode), class: "form-control") %>
-	</div>
+      	<div class="form-group">
+      	    <%= label(f, :route_ids, "Route") %>
+      	    <%= select(f, :route_ids, route_options(@mode), class: "form-control") %>
+      	</div>
 
         <%= if f.params["chart_range"] != "By Station" do %>
           <div class="form-group">
@@ -142,21 +142,28 @@
           <% end %>
         </div>
 
-	<div class="form-group">
-	  <div><strong>Direction ID</strong></div>
+      	<div class="form-group">
+      	  <div><strong>Direction ID</strong></div>
 
-	  <%= label class: "radio-inline" do %>
-	    <%= radio_button(f, :direction_id, "0") %> 0
-	  <% end %>
+      	  <%= label class: "radio-inline" do %>
+      	    <%= radio_button(f, :direction_id, "0") %> 0
+      	  <% end %>
 
-	  <%= label class: "radio-inline" do %>
-	    <%= radio_button(f, :direction_id, "1") %> 1
-	  <% end %>
+      	  <%= label class: "radio-inline" do %>
+      	    <%= radio_button(f, :direction_id, "1") %> 1
+      	  <% end %>
 
-	  <%= label class: "radio-inline" do %>
-	    <%= radio_button(f, :direction_id, "any") %> Any
-	  <% end %>
-	</div>
+      	  <%= label class: "radio-inline" do %>
+      	    <%= radio_button(f, :direction_id, "any") %> Any
+      	  <% end %>
+      	</div>
+
+        <%= if @mode == :subway do %>
+          <div class="form-group">
+            <%= label(f, :kinds, "Kinds") %>
+            <%= multiple_select(f, :kinds, kind_filter_options(), class: 'form-control') %>
+          </div>
+        <% end %>
 
         <div class="form-group">
           <%= label(f, :bin, "Bin") %>

--- a/lib/prediction_analyzer_web/views/accuracy_view.ex
+++ b/lib/prediction_analyzer_web/views/accuracy_view.ex
@@ -90,6 +90,9 @@ defmodule PredictionAnalyzerWeb.AccuracyView do
     end)
   end
 
+  @spec kind_filter_options() :: [{String.t(), String.t()}]
+  def kind_filter_options, do: Filters.kind_labels()
+
   @spec stop_filter_options(PredictionAnalyzer.Utilities.mode()) ::
           %{String.t() => [{String.t(), String.t()}]} | [{String.t(), String.t()}]
   def stop_filter_options(mode) do

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule PredictionAnalyzer.Mixfile do
       "ecto.setup": ["ecto.create", "ecto.load", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "ecto.rollback": ["ecto.rollback", "ecto.dump"],
-      test: ["ecto.create --quiet", "ecto.load --quiet", "test"]
+      test: ["ecto.create --quiet", "ecto.load --quiet", "ecto.migrate --quiet", "test"]
     ]
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -5,31 +5,31 @@ alias PredictionAnalyzer.Predictions.Prediction
 require Logger
 
 stops = [
-  {"Red", "70061", 0},
-  {"Red", "70063", 0},
-  {"Red", "70064", 1},
-  {"Red", "70065", 0},
-  {"Red", "70066", 1},
-  {"Red", "70067", 0},
-  {"Red", "70068", 1},
-  {"Orange", "70036", 0},
-  {"Orange", "70034", 0},
-  {"Orange", "70035", 1},
-  {"Orange", "70032", 0},
-  {"Orange", "70033", 1},
-  {"Orange", "70278", 0},
-  {"Orange", "70279", 1},
-  {"Orange", "70030", 0},
-  {"Orange", "70031", 1},
-  {"CR-Fitchburg", "Waltham", 0},
-  {"CR-Fitchburg", "Waltham", 1},
-  {"CR-Fitchburg", "Belmont", 1},
-  {"CR-Fitchburg", "Belmont", 0},
-  {"CR-Fitchburg", "Fitchburg", 1},
-  {"CR-Fitchburg", "Fitchburg", 0},
-  {"CR-Fitchburg", "Concord", 1},
-  {"CR-Fitchburg", "Concord", 0},
-  {"CR-Fitchburg", "Lincoln", 1}
+  {"Red", "70061", 0, "at_terminal"},
+  {"Red", "70063", 0, "reverse"},
+  {"Red", "70064", 1, "mid_trip"},
+  {"Red", "70065", 0, "reverse"},
+  {"Red", "70066", 1, "mid_trip"},
+  {"Red", "70067", 0, "reverse"},
+  {"Red", "70068", 1, "mid_trip"},
+  {"Orange", "70036", 0, "at_terminal"},
+  {"Orange", "70034", 0, "reverse"},
+  {"Orange", "70035", 1, "mid_trip"},
+  {"Orange", "70032", 0, "reverse"},
+  {"Orange", "70033", 1, "mid_trip"},
+  {"Orange", "70278", 0, "reverse"},
+  {"Orange", "70279", 1, "mid_trip"},
+  {"Orange", "70030", 0, "reverse"},
+  {"Orange", "70031", 1, "mid_trip"},
+  {"CR-Fitchburg", "Waltham", 0, nil},
+  {"CR-Fitchburg", "Waltham", 1, nil},
+  {"CR-Fitchburg", "Belmont", 1, nil},
+  {"CR-Fitchburg", "Belmont", 0, nil},
+  {"CR-Fitchburg", "Fitchburg", 1, nil},
+  {"CR-Fitchburg", "Fitchburg", 0, nil},
+  {"CR-Fitchburg", "Concord", 1, nil},
+  {"CR-Fitchburg", "Concord", 0, nil},
+  {"CR-Fitchburg", "Lincoln", 1, nil}
 ]
 
 Logger.info("Generating sample prediction_accuracy data")
@@ -44,7 +44,7 @@ service_dates =
 for env <- ["prod", "dev-green"],
     service_date <- service_dates,
     hour_of_day <- 4..25,
-    {route_id, stop_id, direction_id} <- stops,
+    {route_id, stop_id, direction_id, kind} <- stops,
     a_d <- ["arrival", "departure"],
     bin <- Map.keys(Filters.bins()) do
   num_predictions = :rand.uniform(100)
@@ -59,6 +59,7 @@ for env <- ["prod", "dev-green"],
     direction_id: direction_id,
     arrival_departure: a_d,
     bin: bin,
+    kind: kind,
     num_predictions: num_predictions,
     num_accurate_predictions: num_accurate_predictions
   }
@@ -72,7 +73,7 @@ end)
 for env <- ["prod", "dev-green"],
     service_date <- service_dates,
     hour_of_day <- 4..25,
-    {route_id, stop_id, direction_id} <- stops do
+    {route_id, stop_id, direction_id, kind} <- stops do
   for i <- 1..:rand.uniform(25) do
     timestamp =
       service_date
@@ -94,6 +95,7 @@ for env <- ["prod", "dev-green"],
       stop_id: stop_id,
       route_id: route_id,
       direction_id: direction_id,
+      kind: kind,
       stop_sequence: 310,
       stops_away: 0,
       vehicle_event_id: nil

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -17,6 +17,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
     route_id: "route1",
     direction_id: 0,
     arrival_departure: "arrival",
+    kind: "mid_trip",
     bin: "0-3 min",
     num_predictions: 10,
     num_accurate_predictions: 5,
@@ -108,6 +109,19 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
       {accs, nil} = PredictionAccuracy.filter(Map.merge(base_params(), %{"direction_id" => "1"}))
       q = from(acc in accs, [])
       assert [%{id: ^acc6_id}] = execute_query(q)
+    end
+
+    test "can filter by kinds" do
+      Repo.insert!(%{@prediction_accuracy | kind: nil})
+      Repo.insert!(%{@prediction_accuracy | kind: "at_terminal"})
+      Repo.insert!(%{@prediction_accuracy | kind: "mid_trip"})
+      Repo.insert!(%{@prediction_accuracy | kind: "reverse"})
+
+      {accs, nil} =
+        PredictionAccuracy.filter(Map.merge(base_params(), %{"kinds" => ~w(mid_trip reverse)}))
+
+      query = from(acc in accs, [])
+      assert [%{kind: "mid_trip"}, %{kind: "reverse"}] = execute_query(query)
     end
 
     test "can filter by multiple routes" do

--- a/test/prediction_analyzer/prediction_accuracy/query_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/query_test.exs
@@ -27,7 +27,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
     direction_id: 0,
     stop_sequence: 10,
     stops_away: 2,
-    vehicle_event_id: nil
+    vehicle_event_id: nil,
+    kind: "mid_trip"
   }
 
   @vehicle_event %VehicleEvent{
@@ -43,7 +44,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
     departure_time: nil
   }
 
-  describe "calculate_aggregate_accuracy/9" do
+  describe "calculate_aggregate_accuracy/10" do
     test "selects the right predictions based on bin and grades them accurately, for arrivals" do
       bin_name = "6-12 min"
       bin_min = 360
@@ -66,6 +67,12 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
         @prediction
         | # too early to be considered
           file_timestamp: file_time - 60 * 90
+      })
+
+      Repo.insert!(%{
+        @prediction
+        | # different kind, should not be considered
+          kind: "at_terminal"
       })
 
       Repo.insert!(%{
@@ -117,6 +124,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
           PredictionAnalyzer.Repo,
           Timex.local(),
           "arrival",
+          "mid_trip",
           bin_name,
           bin_min,
           bin_max,
@@ -131,6 +139,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
       assert pa.route_id == "route1"
       assert pa.arrival_departure == "arrival"
       assert pa.bin == "6-12 min"
+      assert pa.kind == "mid_trip"
       assert pa.num_predictions == 4
       assert pa.num_accurate_predictions == 2
       assert pa.direction_id == 0
@@ -212,6 +221,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
           PredictionAnalyzer.Repo,
           Timex.local(),
           "departure",
+          "mid_trip",
           bin_name,
           bin_min,
           bin_max,
@@ -288,6 +298,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
           PredictionAnalyzer.Repo,
           Timex.local(),
           "arrival",
+          "mid_trip",
           bin_name,
           bin_min,
           bin_max,

--- a/test/prediction_analyzer/predictions/download_test.exs
+++ b/test/prediction_analyzer/predictions/download_test.exs
@@ -48,18 +48,19 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
   end
 
   describe "get_subway_predictions/1" do
-    test "downloads and stores prod predictions" do
+    test "downloads and stores predictions" do
       Download.get_subway_predictions(:prod)
       Download.get_subway_predictions(:dev_green)
-      query = from(p in Prediction, select: [p.environment, p.stop_id, p.direction_id])
+      query = from(p in Prediction, select: [p.environment, p.stop_id, p.direction_id, p.kind])
 
       preds = PredictionAnalyzer.Repo.all(query)
 
+      # See FakeHTTPoison
       assert preds == [
-               ["prod", "70061", 1],
-               ["prod", "70063", 1],
-               ["dev-green", "70061", 1],
-               ["dev-green", "70063", 1]
+               ["prod", "70061", 1, "mid_trip"],
+               ["prod", "70063", 1, "mid_trip"],
+               ["dev-green", "70061", 1, "mid_trip"],
+               ["dev-green", "70063", 1, "mid_trip"]
              ]
     end
   end


### PR DESCRIPTION
**Asana Ticket:** [📈 tracking kind of prediction and being able to filter](https://app.asana.com/0/584764604969369/1187025758962797)

RTR predictions internally have a "kind" which is:

* "at terminal" when the train is waiting to depart from a terminal
* "reverse" when the prediction is on a trip we expect will occur once the train reverses direction at the end of its current trip
* "mid-trip" in all other circumstances

These are not exposed to consumers, but they are mapped to specific values of the `uncertainty` field in stop time updates. Here we reverse that mapping and store/aggregate the "kind" of predictions. This can be null, since the concept is not relevant to Commuter Rail predictions.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
