### PR TITLE
feat: calculate nth_at_stop when downloading subway predictions

### DIFF
--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -334,7 +334,7 @@ defmodule FakeHTTPoison do
               "id" => "vehicle_id"
             },
             "trip" => %{
-              "trip_id" => "TEST_TRIP",
+              "trip_id" => "TEST_TRIP_1",
               "route_id" => "Red",
               "direction_id" => 1
             },
@@ -385,6 +385,130 @@ defmodule FakeHTTPoison do
                 "stop_id" => "70063",
                 "stop_sequence" => 40,
                 "stops_away" => nil
+              }
+            ]
+          }
+        },
+        %{
+          "alert" => nil,
+          "id" => "1540920791_ADDED-1540403419",
+          "is_deleted" => false,
+          "trip_update" => %{
+            "delay" => nil,
+            "vehicle" => %{
+              "id" => "vehicle_id"
+            },
+            "trip" => %{
+              "trip_id" => "TEST_TRIP_2",
+              "route_id" => "Red",
+              "direction_id" => 1
+            },
+            "stop_time_update" => [
+              %{
+                "arrival" => nil,
+                "boarding_status" => nil,
+                "departure" => %{
+                  "delay" => nil,
+                  "time" => 1_540_921_562,
+                  "uncertainty" => 60
+                },
+                "schedule_relationship" => "SCHEDULED",
+                "stop_id" => "Alewife-01",
+                "stop_sequence" => 10,
+                "stops_away" => 0
+              },
+              %{
+                "arrival" => %{
+                  "delay" => nil,
+                  "time" => 1_540_921_660,
+                  "uncertainty" => 60
+                },
+                "boarding_status" => nil,
+                "departure" => %{
+                  "delay" => nil,
+                  "time" => 1_540_921_705,
+                  "uncertainty" => 60
+                },
+                "schedule_relationship" => "SCHEDULED",
+                "stop_id" => "70063",
+                "stop_sequence" => 20,
+                "stops_away" => 1
+              }
+            ]
+          }
+        },
+        %{
+          "alert" => nil,
+          "id" => "1540920791_ADDED-1540403419",
+          "is_deleted" => false,
+          "trip_update" => %{
+            "delay" => nil,
+            "vehicle" => %{
+              "id" => "vehicle_id"
+            },
+            "trip" => %{
+              "trip_id" => "TEST_TRIP_3",
+              "route_id" => "Red",
+              "direction_id" => 1
+            },
+            "stop_time_update" => nil
+          }
+        },
+        %{
+          "alert" => nil,
+          "id" => "1540920791_ADDED-1540403419",
+          "is_deleted" => false,
+          "trip_update" => %{
+            "delay" => nil,
+            "vehicle" => %{
+              "id" => "vehicle_id"
+            },
+            "trip" => %{
+              "trip_id" => "TEST_TRIP_4",
+              "route_id" => "Red",
+              "direction_id" => 1
+            },
+            "stop_time_update" => [
+              %{
+                "arrival" => nil,
+                "boarding_status" => nil,
+                "departure" => %{
+                  "delay" => nil,
+                  "time" => 1_540_921_562,
+                  "uncertainty" => 60
+                },
+                "schedule_relationship" => "SCHEDULED",
+                "stop_id" => nil,
+                "stop_sequence" => 10,
+                "stops_away" => 0
+              }
+            ]
+          }
+        },
+        %{
+          "alert" => nil,
+          "id" => "1540920791_ADDED-1540403419",
+          "is_deleted" => false,
+          "trip_update" => %{
+            "delay" => nil,
+            "vehicle" => %{
+              "id" => "vehicle_id"
+            },
+            "trip" => %{
+              "trip_id" => "TEST_TRIP_5",
+              "route_id" => "Red",
+              "direction_id" => 1
+            },
+            "stop_time_update" => [
+              %{
+                "arrival" => nil,
+                "boarding_status" => nil,
+                "departure" => nil,
+                "passthrough_time" => 1_540_921_705,
+                "schedule_relationship" => "SKIPPED",
+                "stop_id" => "70063",
+                "stop_sequence" => 20,
+                "stops_away" => 1
               }
             ]
           }

--- a/lib/prediction_analyzer/predictions/prediction.ex
+++ b/lib/prediction_analyzer/predictions/prediction.ex
@@ -19,6 +19,7 @@ defmodule PredictionAnalyzer.Predictions.Prediction do
     field(:stops_away, :integer)
     field(:direction_id, :integer)
     field(:kind, :string)
+    field(:nth_at_stop, :integer)
     belongs_to(:vehicle_event, VehicleEvent)
   end
 end

--- a/test/prediction_analyzer/predictions/download_test.exs
+++ b/test/prediction_analyzer/predictions/download_test.exs
@@ -51,16 +51,26 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
     test "downloads and stores predictions" do
       Download.get_subway_predictions(:prod)
       Download.get_subway_predictions(:dev_green)
-      query = from(p in Prediction, select: [p.environment, p.stop_id, p.direction_id, p.kind])
+
+      query =
+        from(p in Prediction,
+          select: [p.environment, p.trip_id, p.stop_id, p.direction_id, p.kind, p.nth_at_stop]
+        )
 
       preds = PredictionAnalyzer.Repo.all(query)
 
       # See FakeHTTPoison
       assert preds == [
-               ["prod", "70061", 1, "mid_trip"],
-               ["prod", "70063", 1, "mid_trip"],
-               ["dev-green", "70061", 1, "mid_trip"],
-               ["dev-green", "70063", 1, "mid_trip"]
+               ["prod", "TEST_TRIP_4", nil, 1, "mid_trip", nil],
+               ["prod", "TEST_TRIP_2", "70061", 1, "mid_trip", 1],
+               ["prod", "TEST_TRIP_1", "70061", 1, "mid_trip", 2],
+               ["prod", "TEST_TRIP_1", "70063", 1, "mid_trip", 1],
+               ["prod", "TEST_TRIP_2", "70063", 1, "mid_trip", 2],
+               ["dev-green", "TEST_TRIP_4", nil, 1, "mid_trip", nil],
+               ["dev-green", "TEST_TRIP_2", "70061", 1, "mid_trip", 1],
+               ["dev-green", "TEST_TRIP_1", "70061", 1, "mid_trip", 2],
+               ["dev-green", "TEST_TRIP_1", "70063", 1, "mid_trip", 1],
+               ["dev-green", "TEST_TRIP_2", "70063", 1, "mid_trip", 2]
              ]
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Collect nth_at_stop data in predictions](https://app.asana.com/0/0/1196327338606456/f)

Followed the choices laid out in the ticket to primarily sort on `arrival_time || departure_time`, additionally sorting predictions with `stops_away` of 0 to the front like realtime signs does. I didn't attempt to replicate any other complicated sign logic.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
