### PR TITLE
Checkbox to filter by what riders see in stations

### DIFF
--- a/lib/prediction_analyzer/filters.ex
+++ b/lib/prediction_analyzer/filters.ex
@@ -109,6 +109,11 @@ defmodule PredictionAnalyzer.Filters do
   def filter_by_kind(q, []), do: {:ok, q}
   def filter_by_kind(q, nil), do: {:ok, q}
 
+  @spec filter_by_in_next_two(Ecto.Query.t(), String.t() | nil) :: {:ok, Ecto.Query.t()}
+  def filter_by_in_next_two(q, "true"), do: {:ok, from(acc in q, where: acc.in_next_two)}
+  def filter_by_in_next_two(q, "false"), do: {:ok, from(acc in q, where: not acc.in_next_two)}
+  def filter_by_in_next_two(q, _value), do: {:ok, q}
+
   @spec filter_by_timeframe(Ecto.Query.t(), any(), any(), any(), any()) ::
           {:ok, Ecto.Query.t()} | {:error, String.t()}
   def filter_by_timeframe(q, chart_range, _date, start_date, end_date)

--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -19,6 +19,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
     field(:num_accurate_predictions, :integer)
     field(:mean_error, :float)
     field(:root_mean_squared_error, :float)
+    field(:in_next_two, :boolean)
   end
 
   def new_insert_changeset(params \\ %{}) do
@@ -53,6 +54,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
          {:ok, q} <- filter_by_arrival_departure(q, params["arrival_departure"]),
          {:ok, q} <- filter_by_bin(q, params["bin"]),
          {:ok, q} <- filter_by_kind(q, params["kinds"]),
+         {:ok, q} <- filter_by_in_next_two(q, params["in_next_two"]),
          {:ok, q} <- filter_by_mode(q, params["mode"]),
          {:ok, q} <-
            filter_by_timeframe(

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -190,6 +190,13 @@
           </div>
         <% end %>
 
+        <%= if @mode == :subway do %>
+            <div class="form-group">
+                <%= checkbox(f, :in_next_two, unchecked_value: "") %>
+                <%= label(f, :in_next_two, "Only what riders see in stations") %>
+            </div>
+        <% end %>
+
         <div class="form-group">
           <%= submit "Filter", class: "btn btn-default" %>
         </div>


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add frontend filter to toggle between "rider in station" predictions ](https://app.asana.com/0/0/1196327338606458/f)

It was easy enough to also support the `in_next_two=false` case with the filter, so I went ahead and did. Note, however, that there's no way currently for the checkbox to send this in as a parameter - it's either `true` if checked or left blank if unchecked.

Ticket didn't specify anything about placement or styling so I just went with what's shown in the attached screenshot. I think it looks find but let me know if you have any feedback:
![Screen Shot 2020-11-05 at 8 40 49 AM](https://user-images.githubusercontent.com/2010157/98248274-b6cb2000-1f42-11eb-95b1-450fb69e0e79.png)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
