### PR TITLE
feat: Aggregate nth_at_stop predictions as in_next_two in accuracy

### DIFF
--- a/lib/prediction_analyzer/prediction_accuracy/aggregator.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/aggregator.ex
@@ -79,13 +79,15 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Aggregator do
           for environment <- ~w(prod dev-green),
               arrival_departure <- ~w(arrival departure),
               kind <- [nil | Map.values(Filters.kinds())],
-              {bin_name, {bin_min, bin_max, bin_error_min, bin_error_max}} <- Filters.bins() do
+              {bin_name, {bin_min, bin_max, bin_error_min, bin_error_max}} <- Filters.bins(),
+              in_next_two? <- [true, false] do
             {:ok, r} =
               Query.calculate_aggregate_accuracy(
                 repo,
                 current_time,
                 arrival_departure,
                 kind,
+                in_next_two?,
                 bin_name,
                 bin_min,
                 bin_max,

--- a/lib/prediction_analyzer/prediction_accuracy/query.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/query.ex
@@ -9,6 +9,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
           DateTime.t(),
           String.t(),
           String.t(),
+          boolean(),
           String.t(),
           integer(),
           integer(),
@@ -21,6 +22,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         current_time,
         arrival_departure,
         kind,
+        in_next_two?,
         bin_name,
         bin_min,
         bin_max,
@@ -47,7 +49,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
       min_unix,
       max_unix,
       environment,
-      kind
+      kind,
+      in_next_two?
     ])
   end
 
@@ -70,6 +73,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         arrival_departure,
         bin,
         kind,
+        in_next_two,
         num_predictions,
         num_accurate_predictions,
         mean_error,
@@ -85,6 +89,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         $3 AS arrival_departure,
         $4 AS bin,
         $12 AS kind,
+        $13 AS in_next_two,
         COUNT(*) AS num_predictions,
         SUM(
           CASE
@@ -110,6 +115,11 @@ defmodule PredictionAnalyzer.PredictionAccuracy.Query do
         AND p.#{arrival_or_departure_time_column} > p.file_timestamp
         AND p.#{arrival_or_departure_time_column} - p.file_timestamp >= $5
         AND p.#{arrival_or_departure_time_column} - p.file_timestamp < $6
+        AND (
+          ($13 AND (p.nth_at_stop IN (1, 2)))
+          OR
+          ((NOT $13) AND (p.nth_at_stop NOT IN (1, 2) OR p.nth_at_stop IS NULL))
+        )
       GROUP BY p.route_id, p.stop_id, p.direction_id
     )
     "


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Collect in_next_two values in prediction_accuracy](https://app.asana.com/0/584764604969369/1196327338606457)



#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
