### PR TITLE
Pin Erlang version in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN if test -z $ERL_COOKIE; then (>&2 echo "No ERL_COOKIE"); exit 1; fi
 WORKDIR /root
 ADD . .
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  git
+
 # Configure Git to use HTTPS in order to avoid issues with the internal MBTA network
 RUN git config --global url.https://github.com/.insteadOf git://github.com/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mix local.hex --force && \
 
 WORKDIR /root/assets/
 RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - && \
-  apt-get install -y nodejs && \
+  apt-get install -y nodejs npm && \
   npm install -g npm@latest
 
 RUN env NODE_ENV=development npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.3 as builder
+FROM hexpm/elixir:1.10.3-erlang-22.3.4-debian-buster-20200224 as builder
 
 ENV MIX_ENV=prod
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /root
 ADD . .
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  git
+  curl git
 
 # Configure Git to use HTTPS in order to avoid issues with the internal MBTA network
 RUN git config --global url.https://github.com/.insteadOf git://github.com/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /root
 ADD . .
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  curl git
+  ca-certificates curl git
 
 # Configure Git to use HTTPS in order to avoid issues with the internal MBTA network
 RUN git config --global url.https://github.com/.insteadOf git://github.com/
@@ -23,7 +23,7 @@ RUN mix local.hex --force && \
 
 WORKDIR /root/assets/
 RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - && \
-  apt-get install -y nodejs npm && \
+  apt-get install -y nodejs && \
   npm install -g npm@latest
 
 RUN env NODE_ENV=development npm ci


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 update prediction_analyzer to use hexpm/elixir container](https://app.asana.com/0/0/1200075745309245/f)

Updated the Docker image to use hexpm/elixir:1.10.3-erlang-22.3.4-debian-buster-20200224 for builds. This pins the Erlang version to 22.3.4, as specified in `.tool-versions`. This new image needs to have `curl`, `git`, and `ca-certificates` installed to ensure Node is installed correctly. These changes are currently running in prod.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
