### PR TITLE
set CI to use postgres 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       DATABASE_USER: postgres
     services:
       postgres:
-        image: postgres:10-bullseye
+        image: postgres:13-bullseye
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 Upgrade postgres in prediction-analyzer](https://app.asana.com/0/584764604969369/1202190609541060/f)

Upgrade Prediction Analyzer's postgres to 13 in CI (and Terraform)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
