### PR TITLE
chore: disable nightly deploys since app currently only has one env

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,8 +1,6 @@
 name: Deploy to ECS
 
 on:
-  schedule:
-    - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** N/A

Disable nightly dev deploys since dev is currently the only environment for this app. 
