### PR TITLE
fix: improve ui, set timezone to eastern time

### DIFF
--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -2356,7 +2356,7 @@ th {
 .table > tfoot > tr > th,
 .table > thead > tr > td,
 .table > thead > tr > th {
-  padding: 8px;
+  padding: 6px;
   line-height: 1.42857143;
   vertical-align: top;
   border-top: 1px solid #ddd;

--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -174,7 +174,7 @@ const renderDashboard = () => {
         },
       },
       x: {
-        height: 200,
+        height: 60,
         label: {
           text: xAxisText,
           position: "outer-center",

--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -174,7 +174,7 @@ const renderDashboard = () => {
         },
       },
       x: {
-        height: 60,
+        height: 200,
         label: {
           text: xAxisText,
           position: "outer-center",

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -155,7 +155,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
         end)
 
       filename =
-        "#{DateTime.utc_now() |> DateTime.to_iso8601()}_PredictionAnalyzer_#{filter_params["date_start"]}_#{filter_params["date_end"]}_#{filter_params["mode"]}_export.csv"
+        "#{Timex.now("America/New_York") |> DateTime.to_iso8601()}_PredictionAnalyzer_#{filter_params["date_start"]}_#{filter_params["date_end"]}_#{filter_params["mode"]}_export.csv"
 
       send_download(
         conn,

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -154,8 +154,13 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
           }
         end)
 
+      date_for_filename =
+        if Map.has_key?(filter_params, "date_start"),
+          do: "#{filter_params["date_start"]}_#{filter_params["date_end"]}",
+          else: filter_params["service_date"]
+
       filename =
-        "#{Timex.now("America/New_York") |> DateTime.to_iso8601()}_PredictionAnalyzer_#{filter_params["date_start"]}_#{filter_params["date_end"]}_#{filter_params["mode"]}_export.csv"
+        "#{Timex.now("America/New_York") |> DateTime.to_iso8601()}_PredictionAnalyzer_#{date_for_filename}_#{filter_params["mode"]}_export.csv"
 
       send_download(
         conn,

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -168,7 +168,6 @@
 
       </div>
     </div>
-
     <div class="col-xs-9">
       <div class="chart-range-links">
         <%= for chart_range <- ["Hourly", "Daily", "By Station"] do %>
@@ -181,11 +180,13 @@
       <% end %>
 
       <div data-prediction-accuracy class="chart" id="chart-prediction-accuracy"></div>
+      <br />
       <div class="col-xs-6">
+        <span class="prod-text prod-text-header">Prod</span>
         <table class="table" id="prod-data-table">
           <tr>
             <th><%= chart_range_scope_header(f.params["chart_range"]) %></th>
-            <th class="prod-text">Prod Accuracy</th>
+            <th class="prod-text">Accuracy</th>
             <th class="prod-text">Err</th>
             <th class="prod-text">RMSE</th>
             <th class="prod-text">Count</th>
@@ -206,10 +207,11 @@
       </div>
 
       <div class="col-xs-6">
+        <span class="dev-green-text dev-green-text-header">Dev Green</span>
         <table class="table" id="dev-green-data-table">
           <tr>
             <th><%= chart_range_scope_header(f.params["chart_range"]) %></th>
-            <th class="dev-green-text">Dev-Green Accuracy</th>
+            <th class="dev-green-text">Accuracy</th>
             <th class="dev-green-text">Err</th>
             <th class="dev-green-text">RMSE</th>
             <th class="dev-green-text">Count</th>
@@ -234,22 +236,20 @@
   window.dataPredictionAccuracyJSON = <%= raw(@chart_data) %>
   // Handle filter reload on CSV download if values changed:
   var form = document.getElementById("accuracy-form");
-  form.addEventListener("input", function () {
-    var csv_submit = document.getElementById('csv-submit-btn')
-    csv_submit.addEventListener('click', function (event) {
-      // Stop the default load:
-      event.preventDefault()
-      // Open CSV download in new tab:
-      default_target = form.target
-      default_action = form.action
-      form.target = "_blank";
-      form.action = "/accuracy/csv"
-      form.submit()
-      // Reload filters:
-      form.target = default_target
-      form.action = default_action
-      form.submit()
-    })
-  }, { once: true });
+  var csv_submit = document.getElementById('csv-submit-btn')
+  csv_submit.addEventListener('click', function (event) {
+    // Stop the default load:
+    event.preventDefault()
+    // Open CSV download in new tab:
+    default_target = form.target
+    default_action = form.action
+    form.target = "_blank";
+    form.action = "/accuracy/csv"
+    form.submit()
+    // Reload filters:
+    form.target = default_target
+    form.action = default_action
+    form.submit()
+  })
 
 </script>

--- a/lib/prediction_analyzer_web/templates/layout/app.html.eex
+++ b/lib/prediction_analyzer_web/templates/layout/app.html.eex
@@ -7,7 +7,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>Prediction analyzer</title>
+    <title>Prediction Analyzer</title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>">
   </head>
 
@@ -20,7 +20,7 @@
         <h1 class="prediction-analyzer-app-title">
           <svg class="mbta-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000"><path d="m499.9953 976.58345c-262.65627 0-475.574-212.92713-475.574-475.58345s212.9177-475.58345 475.574-475.58345 475.58345 212.92716 475.58345 475.58345-212.92713 475.58345-475.58345 475.58345" fill="#022441"/><path d="m500 0c-276.14 0-500 223.853-500 500s223.86 500 500 500 500-223.86 500-500-223.853-500-500-500m0 955.7c-251.675 0-455.691-204.025-455.691-455.7s204.016-455.7 455.691-455.7 455.7 204.025 455.7 455.7-204.02495 455.7-455.7 455.7" fill="#fff"/><path d="m420.89 824.363h158.228v-389.234h236.545v-158.228h-631.325v158.228h236.552z" fill="#fff"/></svg>
 
-          Prediction analyzer
+          Prediction Analyzer
         </h1>
         <%= @inner_content %>
       </main>


### PR DESCRIPTION
A few minor changes to the CSV feature: 

1. Always reload filters upon generating CSV
2. Eastern instead of UTC for filename

This PR also modifies the CSS slightly to generally improve readability when comparing production and dev data.

This PR: 

<img width="1209" alt="Screenshot 2023-05-17 at 7 03 00 AM" src="https://github.com/mbta/prediction_analyzer/assets/6210506/eb53e8db-ef0e-4684-b886-4b461171229e">

Current production: 

<img width="1214" alt="Screenshot 2023-05-17 at 7 03 10 AM" src="https://github.com/mbta/prediction_analyzer/assets/6210506/d0629992-0169-4168-b757-d57b2f88115e">