### PR TITLE
chore: allow nulled vehicle ids

### DIFF
--- a/priv/repo/migrations/20230914092018_allow_nulled_vehicle_ids.exs
+++ b/priv/repo/migrations/20230914092018_allow_nulled_vehicle_ids.exs
@@ -1,0 +1,15 @@
+defmodule PredictionAnalyzer.Repo.Migrations.AllowNulledVehicleIds do
+  use Ecto.Migration
+
+  def up do
+    alter table(:predictions) do
+      modify(:vehicle_id, :string, null: true)
+    end
+  end
+
+  def down do
+    alter table(:predictions) do
+      modify(:vehicle_id, :string, null: false)
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 📈 Fix Prediction Analyzer not showing LR Terminal Prediction accuracy](https://app.asana.com/0/584764604969369/1205477979097985/f)

Allows `null` for `vehicle_id`. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
