### PR TITLE
📈 Add pop-up tip interface elements to Prediction Analyzer

### DIFF
--- a/assets/css/analyzer.scss
+++ b/assets/css/analyzer.scss
@@ -165,3 +165,30 @@
     transform: rotate(360deg);
   }
 }
+
+.explainer {
+  position: relative;
+  display: inline-block;
+}
+
+.explainer .explainer-text {
+  visibility: hidden;
+  min-width: 200px;
+  background-color: black;
+  color: #fff;
+  border-radius: 6px;
+  padding: 5px;
+  position: absolute;
+  z-index: 10;
+  top: -5px;
+  left: 105%;
+}
+
+.explainer:hover .explainer-text {
+  visibility: visible;
+}
+
+.explainer:after {
+  content: "\24D8";
+  font-size: 80%;
+}

--- a/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
+++ b/lib/prediction_analyzer_web/templates/accuracy/index.html.eex
@@ -95,19 +95,21 @@
         <% end %>
 
       	<div class="form-group">
-      	    <%= label(f, :route_ids, "Route") %>
+      	    <%= explainer_label(f, :route_ids, "Route") %>
       	    <%= select(f, :route_ids, route_options(@mode), class: "form-control") %>
       	</div>
 
         <%= if f.params["chart_range"] != "By Station" do %>
           <div class="form-group">
-            <%= label(f, :stop_ids, "Stops") %>
+            <%= explainer_label(f, :stop_ids, "Stops") %>
             <%= multiple_select(f, :stop_ids, stop_filter_options(@mode), class: "form-control") %>
           </div>
         <% end %>
 
       	<div class="form-group">
-      	  <div><strong>Direction ID</strong></div>
+      	  <div>
+            <%= explainer_label(f, :direction_id, "Direction ID") %>
+          </div>
 
       	  <%= label class: "radio-inline" do %>
       	    <%= radio_button(f, :direction_id, "0") %> 0
@@ -123,37 +125,34 @@
       	</div>
         <%= if @mode == :subway do %>
           <div class="form-group">
-            <%= label(f, :kinds, "Kinds") %>
+            <%= explainer_label(f, :kinds, "Kinds") %>
             <%= multiple_select(f, :kinds, kind_filter_options(), class: "form-control") %>
           </div>
         <% end %>
 
         <div class="form-group">
-          <%= label(f, :bin, "Bin") %>
+          <%= explainer_label(f, :bin, "Bin") %>
           <%= select(f, :bin, ["All" | bin_options()], class: "form-control") %>
         </div>
 
         <%= if f.params["chart_range"] == "Hourly" do %>
           <div class="form-group">
-            <%= label(f, :service_date, "Service Date") %>
-            <small>(YYYY-MM-DD)</small>
+            <%= explainer_label(f, :service_date, ["Service Date ", content_tag(:small, "(YYYY-MM-DD)")]) %>
             <%= text_input(f, :service_date, class: "form-control") %>
           </div>
 
           <div class="form-group">
-            <%= label(f, :timeframe_resolution) %>
+            <%= explainer_label(f, :timeframe_resolution) %>
             <%= select(f, :timeframe_resolution, time_resolution_options(), selected: "60", class: "form-control") %>
           </div>
         <% else %>
           <div class="form-group">
-            <%= label(f, :service_date, "Start Date") %>
-            <small>(YYYY-MM-DD)</small>
+            <%= explainer_label(f, :date_start, ["Start Date ", content_tag(:small, "(YYYY-MM-DD)")]) %>
             <%= text_input(f, :date_start, class: "form-control") %>
           </div>
 
           <div class="form-group">
-            <%= label(f, :service_date, "End Date") %>
-            <small>(YYYY-MM-DD)</small>
+            <%= explainer_label(f, :date_end, ["End Date ", content_tag(:small, "(YYYY-MM-DD)")]) %>
             <%= text_input(f, :date_end, class: "form-control") %>
           </div>
         <% end %>
@@ -161,7 +160,7 @@
         <%= if @mode == :subway do %>
             <div class="form-group">
                 <%= checkbox(f, :in_next_two, unchecked_value: "") %>
-                <%= label(f, :in_next_two, "Only what riders see in stations") %>
+                <%= explainer_label(f, :in_next_two, "Only what riders see in stations") %>
             </div>
         <% end %>
 

--- a/lib/prediction_analyzer_web/views/accuracy_view.ex
+++ b/lib/prediction_analyzer_web/views/accuracy_view.ex
@@ -162,4 +162,65 @@ defmodule PredictionAnalyzerWeb.AccuracyView do
       {"60 minutes", "60"}
     ]
   end
+
+  def explainer_label(f, field), do: explainer_label(f, field, humanize(field))
+
+  def explainer_label(f, field, label_text) do
+    label f, field do
+      [
+        label_text,
+        " ",
+        explainer_element(field)
+      ]
+    end
+  end
+
+  defp explainer_element(field), do: explainer_element(field, explainer_text(field))
+
+  defp explainer_element(_, tooltip),
+    do: [
+      content_tag(
+        :span,
+        [
+          content_tag(:div, tooltip, class: "explainer-text")
+        ],
+        class: "explainer"
+      )
+    ]
+
+  defp explainer_text(:route_ids), do: "Limit results to a single route or route type"
+  defp explainer_text(:stop_ids), do: "Limit results to a single stop or set of stops"
+  defp explainer_text(:direction_id), do: "Limit results to a single direction"
+
+  defp explainer_text(:kinds),
+    do: [
+      content_tag(:p, "Limit results to a type/type(s) of predictions:"),
+      content_tag(:ul, [
+        content_tag(:li, "At terminal: Trips that originate at a terminal"),
+        content_tag(:li, "Mid-trip: Trips that do not originate at a terminal"),
+        content_tag(
+          :li,
+          "Reverse trip: Trips that involve a reversal of direction and a departure back to a terminal"
+        )
+      ])
+    ]
+
+  defp explainer_text(:bin),
+    do:
+      "Limit results to predictions that match a certain time period bin (based on the duration of the predicted trip)"
+
+  defp explainer_text(:service_date), do: "Select a service date for which to view predictions"
+
+  defp explainer_text(:date_start),
+    do: "Select a starting date to view past predictions over a period of multiple days"
+
+  defp explainer_text(:date_end),
+    do: "Select an end date to view past predictions over a period of multiple days"
+
+  defp explainer_text(:timeframe_resolution),
+    do: "Adjust the timeframe resolution to view results for smaller timespans"
+
+  defp explainer_text(:in_next_two),
+    do:
+      "Limit results to predictions riders see, i.e. those that are displayed on in-station countdown signs (typically the next two arrival predictions)"
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📈 Add pop-up tip interface elements to Prediction Analyzer](https://app.asana.com/0/584764604969369/1205075854512859/f)

Add new explainer_label component to add an info icon + hover tooltip description for filter fields. 

<img width="434" alt="image" src="https://github.com/mbta/prediction_analyzer/assets/526017/bb1f0ccb-e04e-4cc0-9d88-3389bb2a9b0a">
<img width="610" alt="image" src="https://github.com/mbta/prediction_analyzer/assets/526017/a6cc9cf7-864b-4a13-9bf5-8c83a0638a62">

