### PR TITLE
fix: revert vehicleid / glides changes

### DIFF
--- a/test/prediction_analyzer/prediction_accuracy/query_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/query_test.exs
@@ -6,7 +6,6 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
   alias PredictionAnalyzer.VehicleEvents.VehicleEvent
   alias PredictionAnalyzer.Predictions.Prediction
   alias PredictionAnalyzer.PredictionAccuracy.Query
-  alias PredictionAnalyzer.VehiclePositions.Comparator
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(PredictionAnalyzer.Repo)
@@ -34,40 +33,6 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
   }
 
   @vehicle_event %VehicleEvent{
-    vehicle_id: "vehicle",
-    environment: "dev-green",
-    vehicle_label: "label",
-    is_deleted: false,
-    route_id: "route",
-    direction_id: 0,
-    trip_id: "trip",
-    stop_id: "stop",
-    arrival_time: nil,
-    departure_time: nil
-  }
-
-  @glides_prediction %Prediction{
-    file_timestamp: :os.system_time(:second),
-    vehicle_id: nil,
-    environment: "dev-green",
-    trip_id: "trip",
-    is_deleted: false,
-    delay: 0,
-    arrival_time: nil,
-    boarding_status: nil,
-    departure_time: nil,
-    schedule_relationship: "SCHEDULED",
-    stop_id: "stop",
-    route_id: "route",
-    direction_id: 0,
-    stop_sequence: 10,
-    stops_away: 2,
-    vehicle_event_id: nil,
-    kind: "at_terminal",
-    nth_at_stop: 5
-  }
-
-  @glides_vehicle_event %VehicleEvent{
     vehicle_id: "vehicle",
     environment: "dev-green",
     vehicle_label: "label",
@@ -188,66 +153,6 @@ defmodule PredictionAnalyzer.PredictionAccuracy.QueryTest do
         :math.sqrt((15 * 15 + 45 * 45 + 45 * 45 + 65 * 65) / 4),
         0.001
       )
-    end
-
-    test "accurate prediction for null vehicle ids / glides" do
-      bin_name = "6-12 min"
-      bin_min = 360
-      bin_max = 720
-      bin_error_min = -30
-      bin_error_max = 60
-
-      file_time =
-        :os.system_time(:second) -
-          60 * Application.get_env(:prediction_analyzer, :analysis_lookback_min)
-
-      arrival_time = file_time + 60 * 7
-
-      Repo.insert!(%{
-        @glides_prediction
-        | file_timestamp: file_time,
-          route_id: "route",
-          stop_id: "stop",
-          # accurate
-          # 15 sec error
-          arrival_time: arrival_time - 15
-      })
-
-      Repo.insert!(%{
-        @glides_prediction
-        | file_timestamp: file_time,
-          route_id: "route",
-          stop_id: "stop",
-          # inaccurate
-          # 45 sec error
-          arrival_time: arrival_time - 45
-      })
-
-      ve = Repo.insert!(%{@glides_vehicle_event | arrival_time: arrival_time})
-      Comparator.associate_vehicle_event_with_predictions(ve)
-
-      {:ok, _} =
-        Query.calculate_aggregate_accuracy(
-          PredictionAnalyzer.Repo,
-          Timex.local(),
-          "at_terminal",
-          false,
-          bin_name,
-          bin_min,
-          bin_max,
-          bin_error_min,
-          bin_error_max,
-          "dev-green"
-        )
-
-      [pa] = Repo.all(from(pa in PredictionAccuracy, select: pa))
-      assert pa.stop_id == "stop"
-      assert pa.route_id == "route"
-      assert pa.bin == "6-12 min"
-      assert pa.kind == "at_terminal"
-      assert pa.num_predictions == 2
-      assert pa.num_accurate_predictions == 2
-      assert pa.direction_id == 0
     end
 
     test "grades only the predicted arrival time if available, otherwise the departure time" do


### PR DESCRIPTION
Reverts recently-merged work for supporting Glides predictions w/ null vehicle_id. 

PR was not automatically revertible. 