### PR TITLE
[extra] 🐛📈 Prediction Analyzer data selection goes back one day every time the "Filter" button is clicked

### DIFF
--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -258,10 +258,10 @@ const setupDatePickers = () => {
   }
 
   const normalizeSelectedDate = (value) => {
-    const offset = new Date().getTimezoneOffset()
     const newDate = new Date(value)
+    const offset = newDate.getTimezoneOffset()
 
-    if (newDate.getHours() != 0) {
+    if (newDate.getHours() !== 0) {
       newDate.setHours(newDate.getHours() + offset / 60)
       newDate.setMinutes(newDate.getMinutes() + (offset % 60))
     }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🐛📈 Prediction Analyzer data selection goes back one day every time the "Filter" button is clicked](TICKET_LINK)

* adjust initial date selected based on browser's current offset so that date is not adjusted out of 'correct' date based on timezone. 
