### PR TITLE
chore: bump elixir / erlang versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.14.5-otp-25
-erlang 25.3.2.7
+erlang 25.3.2.9
 nodejs 18.15.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First, get the elixir dependencies within an elixir container
-FROM hexpm/elixir:1.14.2-erlang-25.2-alpine-3.17.0 AS elixir-builder
+FROM hexpm/elixir:1.14.5-erlang-25.3.2.9-alpine-3.17.7 AS elixir-builder
 
 ENV LANG="C.UTF-8" MIX_ENV=prod
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** None

While working on the Glides validation, I realized that the Dockerfile wasn't aligned with the `.tool-versions` version. 

This also brings both dependencies to their latest patch release. 

#### Reviewer Checklist.
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
