### PR TITLE
fix(chart): date picker is back

### DIFF
--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -16,7 +16,6 @@ declare global {
     sortOrderLink: HTMLElement
     dataPoints: DataPoint[]
     dataPredictionAccuracyJSON: any
-    datePickerCreated: boolean
     chartType: string
     timeframeResolution: string
   }

--- a/assets/src/chart.ts
+++ b/assets/src/chart.ts
@@ -16,6 +16,7 @@ declare global {
     sortOrderLink: HTMLElement
     dataPoints: DataPoint[]
     dataPredictionAccuracyJSON: any
+    datePickerCreated: boolean
     chartType: string
     timeframeResolution: string
   }
@@ -319,11 +320,12 @@ const setupDatePickers = () => {
       formatter: dateFormatter,
       showAllDates: true,
     })
+    document.getElementById("chart-prediction-accuracy")?.setAttribute("datePickerAdded", "true");
   }
 }
 
 const setupDashboard = () => {
-  if (!document.getElementById("chart-prediction-accuracy")) {
+  if (!document.getElementById("chart-prediction-accuracy")?.hasAttribute("datePickerAdded")) {
     setupDatePickers()
   }
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] 🐛📈 Fix Prediction Analyzer calendar picker](https://app.asana.com/0/584764604969369/1209814602688445/f)

Problem:
The calendar date picker is not appearing when you click on the service date anymore since we added `dev-blue` as an RTR environment

Solution:
I borked some of the logic for adding the date pickers - they were getting added twice after some changes I made in service of getting the chart and tables ("dashboard") to actually re-render whenever the "show dev green/blue" checkboxes are clicked. I fixed this logic. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
