### PR TITLE
feat(bug/1D:MU): add `vehicle` `stop_id` `environment` logfmt metadata to departure logs

### DIFF
--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -117,7 +117,9 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     |> Repo.update_all([])
     |> case do
       {0, _} ->
-        Logger.warn("Tried to update departure time, but no arrival for #{vehicle.label}")
+        Logger.warn(
+          "Tried to update departure time, but no arrival vehicle=#{vehicle.label} stop_id=#{vehicle.stop_id} environment=#{vehicle.environment}"
+        )
 
       {1, [ve]} ->
         Logger.info(


### PR DESCRIPTION
#### Summary of changes
I'm trying to determine in Splunk if departures are registering or not, but it's a bit harder to write a query without logfmt formatted information to slice on. So this adds `vehicle` `stop_id` and `environment` logfmt "metadata" like the other logs.

#### Reviewer Checklist
- [x] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
