### PR TITLE
feat(vehicle_positions/comparator): bespoke max_dwell_time for mattapan

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,11 @@ config :prediction_analyzer, :api_base_url, "https://api-v3.mbta.com/"
 config :prediction_analyzer, :migration_task, Predictions.ReleaseTasks.NoOp
 config :prediction_analyzer, :stop_name_fetcher, PredictionAnalyzer.StopNameFetcher
 config :prediction_analyzer, :timezone, "America/New_York"
-config :prediction_analyzer, :max_dwell_time_sec, 30 * 60
+
+config :prediction_analyzer, :max_dwell_time_sec,
+  default: 30 * 60,
+  mattapan: 20 * 60
+
 config :prediction_analyzer, :prune_lookback_sec, 7 * 24 * 60 * 60
 config :prediction_analyzer, :analysis_lookback_min, 40
 

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -24,10 +24,9 @@ defmodule PredictionAnalyzer.Pruner do
     Logger.info("Beginning prune of DB")
 
     prune_lookback_sec = Application.get_env(:prediction_analyzer, :prune_lookback_sec)
-    max_dwell_time_sec = Application.get_env(:prediction_analyzer, :max_dwell_time_sec)[:default]
 
     predictions_cutoff = System.system_time(:second) - prune_lookback_sec
-    vehicle_events_cutoff = predictions_cutoff - max_dwell_time_sec
+    vehicle_events_cutoff = predictions_cutoff - max_dwell_time_sec()
 
     {time, _} =
       :timer.tc(fn ->
@@ -57,6 +56,18 @@ defmodule PredictionAnalyzer.Pruner do
     schedule_next_run(self())
     {:noreply, state}
   end
+
+  # The `max_dwell_time_sec` configuration used to be a single value for
+  # all usages but now contains bespoke values for certain circumstances,
+  # such as the Mattapan line. Despite this, that information is not in the
+  # `VehicleEvent`'s table. To keep the Pruner running as is, it uses the largest
+  # value of the configuration list, to avoid pruning any `VehicleEvent`'s
+  # too soon.
+  defp max_dwell_time_sec,
+    do:
+      Application.get_env(:prediction_analyzer, :max_dwell_time_sec)
+      |> Keyword.values()
+      |> Enum.max()
 
   @spec schedule_next_run(pid()) :: reference()
   defp schedule_next_run(pid) do

--- a/lib/prediction_analyzer/pruner.ex
+++ b/lib/prediction_analyzer/pruner.ex
@@ -24,7 +24,7 @@ defmodule PredictionAnalyzer.Pruner do
     Logger.info("Beginning prune of DB")
 
     prune_lookback_sec = Application.get_env(:prediction_analyzer, :prune_lookback_sec)
-    max_dwell_time_sec = Application.get_env(:prediction_analyzer, :max_dwell_time_sec)
+    max_dwell_time_sec = Application.get_env(:prediction_analyzer, :max_dwell_time_sec)[:default]
 
     predictions_cutoff = System.system_time(:second) - prune_lookback_sec
     vehicle_events_cutoff = predictions_cutoff - max_dwell_time_sec

--- a/lib/prediction_analyzer/vehicle_positions/comparator.ex
+++ b/lib/prediction_analyzer/vehicle_positions/comparator.ex
@@ -109,7 +109,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
 
   @spec record_departure(Vehicle.t()) :: nil
   defp record_departure(vehicle) do
-    max_dwell_time_sec = Application.get_env(:prediction_analyzer, :max_dwell_time_sec)
+    max_dwell_time_sec = max_dwell_time(vehicle)
 
     from(
       ve in VehicleEvent,
@@ -148,6 +148,14 @@ defmodule PredictionAnalyzer.VehiclePositions.Comparator do
     end
 
     nil
+  end
+
+  defp max_dwell_time(%Vehicle{route_id: "Mattapan"}) do
+    Application.get_env(:prediction_analyzer, :max_dwell_time_sec)[:mattapan]
+  end
+
+  defp max_dwell_time(_vehicle) do
+    Application.get_env(:prediction_analyzer, :max_dwell_time_sec)[:default]
   end
 
   @spec vehicle_params(Vehicle.t()) :: map()

--- a/test/prediction_analyzer/pruner_test.exs
+++ b/test/prediction_analyzer/pruner_test.exs
@@ -49,7 +49,7 @@ defmodule PredictionAnalyzer.PrunerTest do
   end
 
   test "prune deletes predictions that are older than lookback period with dwell time grace period for vehicle events" do
-    max_dwell_time_sec = Application.get_env(:prediction_analyzer, :max_dwell_time_sec)
+    max_dwell_time_sec = Application.get_env(:prediction_analyzer, :max_dwell_time_sec)[:default]
     prune_lookback_sec = Application.get_env(:prediction_analyzer, :prune_lookback_sec)
 
     prune_cutoff = System.system_time(:second) - prune_lookback_sec


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔮📈 Investigate and fix "one departure, multiple events" errors at Mattapan (70276)](https://app.asana.com/1/15492006741476/project/1203014709808707/task/1211176719559267?focus=true)

This shortens the amount of time used to look back for previous arrivals when matching departures.

On Mattapan, a train can do a round trip faster than our current `max_dwell_time` of 30m. This means that previous arrivals without departures are then left "eligible" for matching future departures.

[Splunk Dashboard Showing the change of when this branch was deployed between `2025-08-19T15:09:21.392-04:00` and `2025-08-25T10:12:38.972-04:00`](https://mbta.splunkcloud.com/en-US/app/search/transit_datainvestigation_1dmu_max-dwell-time?form.cfg_dd_span=span%3D1h&form.cfg_timechart_span=span%3D123s&form.event-1dmu=One+departure%2C+multiple+updates&form.global_time.earliest=2025-08-18T04%3A00%3A00.000Z&form.global_time.latest=2025-08-26T04%3A00%3A00.000Z&form.pa-indexes=prediction-analyzer-prod&form.pa-indexes=prediction-analyzer-dev&form.usercfg_dd_compare_environment=prod&form.usercfg_ms_environments=prod&form.usercfg_ms_environments=dev-blue&form.usercfg_stop_id=70276&tab=layout_1i7C3Hcc) 

This doesn't address the underlying issue of multiple arrivals or departures not being caught, but it at least reduces the amount of "one departure multiple updates" by up to 50% in non-LRTP environments.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
