### PR TITLE
chore: add 70512 as generic stop ID of 70511

### DIFF
--- a/lib/prediction_analyzer/utilities.ex
+++ b/lib/prediction_analyzer/utilities.ex
@@ -100,6 +100,8 @@ defmodule PredictionAnalyzer.Utilities do
   def generic_stop_id("Oak Grove-01"), do: "70036"
   def generic_stop_id("Oak Grove-02"), do: "70036"
   def generic_stop_id("Union Square-" <> _), do: "70503"
+  # Trains incoming at 70511 will later show up as stopped at 70512
+  def generic_stop_id("70511"), do: "70512"
   def generic_stop_id(stop_id), do: stop_id
 
   @spec routes_for_mode(atom()) :: [String.t()]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔮 More correct stop handling at Medford / Tufts](https://app.asana.com/1/15492006741476/project/584764604969369/task/1211001256151192?focus=true)

Since we're now no longer publishing trains `STOPPED_AT` 70511, they won't register as arriving there. With this change, predictions for direction 1 trains still show up and get graded as arrival predictions at 70512, so we will continue to be able to track their accuracy.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
