### PR TITLE
feat: Run accuracy endpoint queries concurrently

### DIFF
--- a/lib/prediction_analyzer/application.ex
+++ b/lib/prediction_analyzer/application.ex
@@ -13,7 +13,8 @@ defmodule PredictionAnalyzer.Application do
       PredictionAnalyzer.Repo,
       {Oban, Application.fetch_env!(:prediction_analyzer, Oban)},
       {Phoenix.PubSub, name: PredictionAnalyzerWeb.PubSub},
-      PredictionAnalyzerWeb.Endpoint
+      PredictionAnalyzerWeb.Endpoint,
+      {Task.Supervisor, name: PredictionAnalyzer.TaskSupervisor}
     ]
 
     workers =

--- a/lib/prediction_analyzer/filters.ex
+++ b/lib/prediction_analyzer/filters.ex
@@ -38,29 +38,44 @@ defmodule PredictionAnalyzer.Filters do
   @spec kind_labels() :: [{String.t(), String.t()}]
   def kind_labels, do: @kind_labels
 
-  @spec filter_by_route(Ecto.Query.t(), any()) :: {:ok, Ecto.Query.t()} | {:error, String.t()}
-  def filter_by_route(q, route_ids) when is_binary(route_ids) and route_ids != "" do
-    route_id_list = String.split(route_ids, ",")
-    {:ok, from(acc in q, where: acc.route_id in ^route_id_list)}
+  @spec filter_by_route(Ecto.Query.t(), any(), any()) ::
+          {:ok, Ecto.Query.t()} | {:error, String.t()}
+  def filter_by_route(q, route_ids, mode) do
+    # The "route_ids" and "mode" filters both translate to checks on the DB column prediction_accuracy.route_id.
+    # We can improve query performance by simplifying to a single membership check against the intersection of the two.
+    route_ids_from_route_ids_filter =
+      if is_binary(route_ids) and route_ids != "" do
+        route_ids
+        |> String.split(",")
+        |> MapSet.new()
+      else
+        nil
+      end
+
+    route_ids_from_mode_filter =
+      if is_binary(mode) and mode != "" do
+        mode
+        |> PredictionAnalyzer.Utilities.string_to_mode()
+        |> PredictionAnalyzer.Utilities.routes_for_mode()
+        |> MapSet.new()
+      else
+        nil
+      end
+
+    filter_sets = [route_ids_from_route_ids_filter, route_ids_from_mode_filter]
+
+    if Enum.all?(filter_sets, &is_nil/1) do
+      {:ok, q}
+    else
+      route_id_list =
+        filter_sets
+        |> Enum.reject(&is_nil/1)
+        |> Enum.reduce(&MapSet.intersection/2)
+        |> Enum.sort()
+
+      {:ok, from(acc in q, where: acc.route_id in ^route_id_list)}
+    end
   end
-
-  def filter_by_route(q, _), do: {:ok, q}
-
-  @spec filter_by_mode(Ecto.Query.t(), any()) :: {:ok, Ecto.Query.t()} | {:error, String.t()}
-  def filter_by_mode(q, mode) when is_binary(mode) and mode != "" do
-    routes =
-      mode
-      |> PredictionAnalyzer.Utilities.string_to_mode()
-      |> PredictionAnalyzer.Utilities.routes_for_mode()
-
-    {:ok,
-     from(
-       acc in q,
-       where: acc.route_id in ^routes
-     )}
-  end
-
-  def filter_by_mode(q, _), do: {:ok, q}
 
   @spec filter_by_stop(Ecto.Query.t(), [String.t()]) ::
           {:ok, Ecto.Query.t()} | {:error, String.t()}

--- a/lib/prediction_analyzer/filters.ex
+++ b/lib/prediction_analyzer/filters.ex
@@ -150,17 +150,13 @@ defmodule PredictionAnalyzer.Filters do
 
   hour | prod total | prod accurate | dev-green total | dev-green accurate
   """
-  @spec stats_by_environment_and_chart_range(Ecto.Query.t(), String.t(), map()) :: Ecto.Query.t()
-  def stats_by_environment_and_chart_range(q, environment, %{
-        "chart_range" => "Hourly",
-        "timeframe_resolution" => tr
-      })
+  @spec stats_by_chart_range(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  def stats_by_chart_range(q, %{"chart_range" => "Hourly", "timeframe_resolution" => tr})
       when tr != "60" do
     from(
       acc in q,
       group_by: [:hour_of_day, fragment("resolution_bucket")],
       order_by: [:hour_of_day, fragment("resolution_bucket")],
-      where: acc.environment == ^environment,
       select: [
         {acc.hour_of_day, resolution_bucket(acc.minute_of_hour, ^String.to_integer(tr))},
         sum(acc.num_predictions),
@@ -171,7 +167,7 @@ defmodule PredictionAnalyzer.Filters do
     )
   end
 
-  def stats_by_environment_and_chart_range(q, environment, filters) do
+  def stats_by_chart_range(q, filters) do
     scope =
       case filters["chart_range"] do
         "Daily" -> :service_date
@@ -183,7 +179,6 @@ defmodule PredictionAnalyzer.Filters do
       acc in q,
       group_by: ^scope,
       order_by: ^scope,
-      where: acc.environment == ^environment,
       select: [
         field(acc, ^scope),
         sum(acc.num_predictions),

--- a/lib/prediction_analyzer/prediction_accuracy/accuracy_tracker.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/accuracy_tracker.ex
@@ -3,6 +3,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.AccuracyTracker do
 
   alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
   alias PredictionAnalyzer.Filters
+  import Ecto.Query, only: [where: 2]
   require Logger
 
   @drop_threshold 0.1
@@ -41,9 +42,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.AccuracyTracker do
 
     yesterday_accs =
       yesterday_query
-      |> Filters.stats_by_environment_and_chart_range("prod", %{
-        "chart_range" => "Hourly"
-      })
+      |> Filters.stats_by_chart_range(%{"chart_range" => "Hourly"})
+      |> where(environment: "prod")
       |> PredictionAnalyzer.Repo.all()
 
     {previous_day_query, _} =
@@ -55,9 +55,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.AccuracyTracker do
 
     previous_day_accs =
       previous_day_query
-      |> Filters.stats_by_environment_and_chart_range("prod", %{
-        "chart_range" => "Hourly"
-      })
+      |> Filters.stats_by_chart_range(%{"chart_range" => "Hourly"})
+      |> where(environment: "prod")
       |> PredictionAnalyzer.Repo.all()
 
     yesterday_accuracy = get_accuracy(yesterday_accs)

--- a/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
+++ b/lib/prediction_analyzer/prediction_accuracy/prediction_accuracy.ex
@@ -47,13 +47,12 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy do
   def filter(params) do
     q = from(acc in __MODULE__, [])
 
-    with {:ok, q} <- filter_by_route(q, params["route_ids"]),
+    with {:ok, q} <- filter_by_route(q, params["route_ids"], params["mode"]),
          {:ok, q} <- filter_by_stop(q, params["stop_ids"]),
          {:ok, q} <- filter_by_direction(q, params["direction_id"]),
          {:ok, q} <- filter_by_bin(q, params["bin"]),
          {:ok, q} <- filter_by_kind(q, params["kinds"]),
          {:ok, q} <- filter_by_in_next_two(q, params["in_next_two"]),
-         {:ok, q} <- filter_by_mode(q, params["mode"]),
          {:ok, q} <-
            filter_by_timeframe(
              q,

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -3,7 +3,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
   alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
   alias PredictionAnalyzer.Filters
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, where: 2]
   import PredictionAnalyzer.QueryUtilities, only: [aggregate_mean_error: 2, aggregate_rmse: 2]
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
@@ -87,7 +87,8 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
 
       prod_accuracies =
         relevant_accuracies
-        |> Filters.stats_by_environment_and_chart_range("prod", filter_params)
+        |> Filters.stats_by_chart_range(filter_params)
+        |> where(environment: "prod")
         |> PredictionAnalyzer.Repo.all(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
           telemetry_options: [name: :accuracies, env: :prod, request_params: params_string]
@@ -98,7 +99,8 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
 
       dev_green_accuracies =
         relevant_accuracies
-        |> Filters.stats_by_environment_and_chart_range("dev-green", filter_params)
+        |> Filters.stats_by_chart_range(filter_params)
+        |> where(environment: "dev-green")
         |> PredictionAnalyzer.Repo.all(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
           telemetry_options: [name: :accuracies, env: :dev_green, request_params: params_string]
@@ -109,7 +111,8 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
 
       dev_blue_accuracies =
         relevant_accuracies
-        |> Filters.stats_by_environment_and_chart_range("dev-blue", filter_params)
+        |> Filters.stats_by_chart_range(filter_params)
+        |> where(environment: "dev-blue")
         |> PredictionAnalyzer.Repo.all(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
           telemetry_options: [name: :accuracies, env: :dev_blue, request_params: params_string]
@@ -188,9 +191,10 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
     if time_filters_present?(filter_params) do
       {relevant_accuracies, _} = PredictionAccuracy.filter(filter_params)
 
+      accuracies_by_chart_range = Filters.stats_by_chart_range(relevant_accuracies, filter_params)
+
       prod_accuracies =
-        relevant_accuracies
-        |> Filters.stats_by_environment_and_chart_range("prod", filter_params)
+        from(acc in accuracies_by_chart_range, where: acc.environment == "prod")
         |> PredictionAnalyzer.Repo.all()
         |> Enum.map(fn [row_scope, prod_total, prod_accurate, prod_err, prod_rmse] ->
           %{

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -20,13 +20,9 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
         } = params
       )
       when not is_nil(route_ids) and not is_nil(direction_id) and byte_size(bin) > 0 do
-    mode_atom = PredictionAnalyzer.Utilities.string_to_mode(mode)
-    routes = PredictionAnalyzer.Utilities.routes_for_mode(mode_atom)
-
-    request_uri = conn |> current_url(params) |> URI.parse()
-    params_string = request_uri.query
-
     if time_filters_present?(filter_params) do
+      %{query: params_string} = conn |> current_url(params) |> URI.parse()
+
       {relevant_accuracies, error_msg} = PredictionAccuracy.filter(filter_params)
 
       [prod_num_accurate, prod_num_predictions, prod_mean_error, prod_rmse] =
@@ -38,7 +34,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
             aggregate_mean_error(acc.mean_error, acc.num_predictions),
             aggregate_rmse(acc.root_mean_squared_error, acc.num_predictions)
           ],
-          where: acc.environment == "prod" and acc.route_id in ^routes
+          where: acc.environment == "prod"
         )
         |> PredictionAnalyzer.Repo.one!(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
@@ -54,7 +50,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
             aggregate_mean_error(acc.mean_error, acc.num_predictions),
             aggregate_rmse(acc.root_mean_squared_error, acc.num_predictions)
           ],
-          where: acc.environment == "dev-green" and acc.route_id in ^routes
+          where: acc.environment == "dev-green"
         )
         |> PredictionAnalyzer.Repo.one!(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
@@ -74,7 +70,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
             aggregate_mean_error(acc.mean_error, acc.num_predictions),
             aggregate_rmse(acc.root_mean_squared_error, acc.num_predictions)
           ],
-          where: acc.environment == "dev-blue" and acc.route_id in ^routes
+          where: acc.environment == "dev-blue"
         )
         |> PredictionAnalyzer.Repo.one!(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
@@ -159,7 +155,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
         dev_blue_mean_error: dev_blue_mean_error,
         dev_blue_rmse: dev_blue_rmse,
         error_msg: error_msg,
-        mode: mode_atom,
+        mode: PredictionAnalyzer.Utilities.string_to_mode(mode),
         bins:
           Filters.bins()
           |> Enum.map(fn {bin, {bin_min, _bin_max, bin_error_min, bin_error_max}} ->

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -3,7 +3,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
   alias PredictionAnalyzer.PredictionAccuracy.PredictionAccuracy
   alias PredictionAnalyzer.Filters
 
-  import Ecto.Query, only: [from: 2, where: 2]
+  import Ecto.Query, only: [from: 2]
   import PredictionAnalyzer.QueryUtilities, only: [aggregate_mean_error: 2, aggregate_rmse: 2]
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
@@ -27,93 +27,17 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
       accuracies_by_chart_range = Filters.stats_by_chart_range(relevant_accuracies, filter_params)
 
       [prod_num_accurate, prod_num_predictions, prod_mean_error, prod_rmse] =
-        from(
-          acc in relevant_accuracies,
-          select: [
-            sum(acc.num_accurate_predictions),
-            sum(acc.num_predictions),
-            aggregate_mean_error(acc.mean_error, acc.num_predictions),
-            aggregate_rmse(acc.root_mean_squared_error, acc.num_predictions)
-          ],
-          where: acc.environment == "prod"
-        )
-        |> PredictionAnalyzer.Repo.one!(
-          telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
-          telemetry_options: [name: :accuracy_context, env: :prod, request_params: params_string]
-        )
+        get_accuracy_context(relevant_accuracies, params_string, "prod")
 
       [dev_green_num_accurate, dev_green_num_predictions, dev_green_mean_error, dev_green_rmse] =
-        from(
-          acc in relevant_accuracies,
-          select: [
-            sum(acc.num_accurate_predictions),
-            sum(acc.num_predictions),
-            aggregate_mean_error(acc.mean_error, acc.num_predictions),
-            aggregate_rmse(acc.root_mean_squared_error, acc.num_predictions)
-          ],
-          where: acc.environment == "dev-green"
-        )
-        |> PredictionAnalyzer.Repo.one!(
-          telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
-          telemetry_options: [
-            name: :accuracy_context,
-            env: :dev_green,
-            request_params: params_string
-          ]
-        )
+        get_accuracy_context(relevant_accuracies, params_string, "dev-green")
 
       [dev_blue_num_accurate, dev_blue_num_predictions, dev_blue_mean_error, dev_blue_rmse] =
-        from(
-          acc in relevant_accuracies,
-          select: [
-            sum(acc.num_accurate_predictions),
-            sum(acc.num_predictions),
-            aggregate_mean_error(acc.mean_error, acc.num_predictions),
-            aggregate_rmse(acc.root_mean_squared_error, acc.num_predictions)
-          ],
-          where: acc.environment == "dev-blue"
-        )
-        |> PredictionAnalyzer.Repo.one!(
-          telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
-          telemetry_options: [
-            name: :accuracy_context,
-            env: :dev_blue,
-            request_params: params_string
-          ]
-        )
+        get_accuracy_context(relevant_accuracies, params_string, "dev-blue")
 
-      prod_accuracies =
-        accuracies_by_chart_range
-        |> where(environment: "prod")
-        |> PredictionAnalyzer.Repo.all(
-          telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
-          telemetry_options: [name: :accuracies, env: :prod, request_params: params_string]
-        )
-        |> Map.new(fn [scope, _num_predictions, _num_accurate, _mean_error, _rmse] = accuracy ->
-          {scope, accuracy}
-        end)
-
-      dev_green_accuracies =
-        accuracies_by_chart_range
-        |> where(environment: "dev-green")
-        |> PredictionAnalyzer.Repo.all(
-          telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
-          telemetry_options: [name: :accuracies, env: :dev_green, request_params: params_string]
-        )
-        |> Map.new(fn [scope, _num_predictions, _num_accurate, _mean_error, _rmse] = accuracy ->
-          {scope, accuracy}
-        end)
-
-      dev_blue_accuracies =
-        accuracies_by_chart_range
-        |> where(environment: "dev-blue")
-        |> PredictionAnalyzer.Repo.all(
-          telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
-          telemetry_options: [name: :accuracies, env: :dev_blue, request_params: params_string]
-        )
-        |> Map.new(fn [scope, _num_predictions, _num_accurate, _mean_error, _rmse] = accuracy ->
-          {scope, accuracy}
-        end)
+      prod_accuracies = get_accuracies(accuracies_by_chart_range, params_string, "prod")
+      dev_green_accuracies = get_accuracies(accuracies_by_chart_range, params_string, "dev-green")
+      dev_blue_accuracies = get_accuracies(accuracies_by_chart_range, params_string, "dev-blue")
 
       sort_function =
         if filter_params["chart_range"] == "Daily" do
@@ -168,6 +92,34 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
 
   def index(conn, params) do
     redirect_with_default_filters(conn, params)
+  end
+
+  defp get_accuracy_context(relevant_accuracies, params_string, env) do
+    from(
+      acc in relevant_accuracies,
+      select: [
+        sum(acc.num_accurate_predictions),
+        sum(acc.num_predictions),
+        aggregate_mean_error(acc.mean_error, acc.num_predictions),
+        aggregate_rmse(acc.root_mean_squared_error, acc.num_predictions)
+      ],
+      where: acc.environment == ^env
+    )
+    |> PredictionAnalyzer.Repo.one!(
+      telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
+      telemetry_options: [name: :accuracy_context, env: env, request_params: params_string]
+    )
+  end
+
+  defp get_accuracies(accuracies_by_chart_range, params_string, env) do
+    from(acc in accuracies_by_chart_range, where: acc.environment == ^env)
+    |> PredictionAnalyzer.Repo.all(
+      telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
+      telemetry_options: [name: :accuracies, env: env, request_params: params_string]
+    )
+    |> Map.new(fn [scope, _num_predictions, _num_accurate, _mean_error, _rmse] = accuracy ->
+      {scope, accuracy}
+    end)
   end
 
   def subway(conn, params) do

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -24,6 +24,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
       %{query: params_string} = conn |> current_url(params) |> URI.parse()
 
       {relevant_accuracies, error_msg} = PredictionAccuracy.filter(filter_params)
+      accuracies_by_chart_range = Filters.stats_by_chart_range(relevant_accuracies, filter_params)
 
       [prod_num_accurate, prod_num_predictions, prod_mean_error, prod_rmse] =
         from(
@@ -82,8 +83,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
         )
 
       prod_accuracies =
-        relevant_accuracies
-        |> Filters.stats_by_chart_range(filter_params)
+        accuracies_by_chart_range
         |> where(environment: "prod")
         |> PredictionAnalyzer.Repo.all(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
@@ -94,8 +94,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
         end)
 
       dev_green_accuracies =
-        relevant_accuracies
-        |> Filters.stats_by_chart_range(filter_params)
+        accuracies_by_chart_range
         |> where(environment: "dev-green")
         |> PredictionAnalyzer.Repo.all(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],
@@ -106,8 +105,7 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
         end)
 
       dev_blue_accuracies =
-        relevant_accuracies
-        |> Filters.stats_by_chart_range(filter_params)
+        accuracies_by_chart_range
         |> where(environment: "dev-blue")
         |> PredictionAnalyzer.Repo.all(
           telemetry_event: PredictionAnalyzer.Repo.config()[:telemetry_prefix] ++ [:named_query],

--- a/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
+++ b/lib/prediction_analyzer_web/controllers/accuracy_controller.ex
@@ -6,6 +6,8 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
   import Ecto.Query, only: [from: 2]
   import PredictionAnalyzer.QueryUtilities, only: [aggregate_mean_error: 2, aggregate_rmse: 2]
 
+  @envs ["prod", "dev-green", "dev-blue"]
+
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(
         conn,
@@ -26,18 +28,30 @@ defmodule PredictionAnalyzerWeb.AccuracyController do
       {relevant_accuracies, error_msg} = PredictionAccuracy.filter(filter_params)
       accuracies_by_chart_range = Filters.stats_by_chart_range(relevant_accuracies, filter_params)
 
-      [prod_num_accurate, prod_num_predictions, prod_mean_error, prod_rmse] =
-        get_accuracy_context(relevant_accuracies, params_string, "prod")
+      accuracy_context_tasks =
+        for env <- @envs do
+          Task.Supervisor.async(
+            PredictionAnalyzer.TaskSupervisor,
+            fn -> get_accuracy_context(relevant_accuracies, params_string, env) end
+          )
+        end
 
-      [dev_green_num_accurate, dev_green_num_predictions, dev_green_mean_error, dev_green_rmse] =
-        get_accuracy_context(relevant_accuracies, params_string, "dev-green")
+      accuracy_tasks =
+        for env <- @envs do
+          Task.Supervisor.async(
+            PredictionAnalyzer.TaskSupervisor,
+            fn -> get_accuracies(accuracies_by_chart_range, params_string, env) end
+          )
+        end
 
-      [dev_blue_num_accurate, dev_blue_num_predictions, dev_blue_mean_error, dev_blue_rmse] =
-        get_accuracy_context(relevant_accuracies, params_string, "dev-blue")
-
-      prod_accuracies = get_accuracies(accuracies_by_chart_range, params_string, "prod")
-      dev_green_accuracies = get_accuracies(accuracies_by_chart_range, params_string, "dev-green")
-      dev_blue_accuracies = get_accuracies(accuracies_by_chart_range, params_string, "dev-blue")
+      [
+        [prod_num_accurate, prod_num_predictions, prod_mean_error, prod_rmse],
+        [dev_green_num_accurate, dev_green_num_predictions, dev_green_mean_error, dev_green_rmse],
+        [dev_blue_num_accurate, dev_blue_num_predictions, dev_blue_mean_error, dev_blue_rmse],
+        prod_accuracies,
+        dev_green_accuracies,
+        dev_blue_accuracies
+      ] = Task.await_many(accuracy_context_tasks ++ accuracy_tasks, :timer.minutes(5))
 
       sort_function =
         if filter_params["chart_range"] == "Daily" do

--- a/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
+++ b/test/prediction_analyzer/prediction_accuracy/prediction_accuracy_test.exs
@@ -4,7 +4,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
   alias PredictionAnalyzer.Filters
   alias PredictionAnalyzer.Repo
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, where: 2]
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
@@ -255,7 +255,7 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
     end
   end
 
-  describe "stats_by_environment_and_chart_range/3" do
+  describe "stats_by_chart_range/3" do
     test "groups by environment and hour and sums" do
       insert_accuracy("prod", 10, 0, 101, 99)
       insert_accuracy("prod", 10, 0, 108, 102)
@@ -268,16 +268,14 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       prod_stats =
         from(acc in PredictionAccuracy, [])
-        |> Filters.stats_by_environment_and_chart_range("prod", %{
-          "chart_range" => "Hourly"
-        })
+        |> Filters.stats_by_chart_range(%{"chart_range" => "Hourly"})
+        |> where(environment: "prod")
         |> Repo.all()
 
       dev_green_stats =
         from(acc in PredictionAccuracy, [])
-        |> Filters.stats_by_environment_and_chart_range("dev-green", %{
-          "chart_range" => "Hourly"
-        })
+        |> Filters.stats_by_chart_range(%{"chart_range" => "Hourly"})
+        |> where(environment: "dev-green")
         |> Repo.all()
 
       assert prod_stats == [
@@ -306,16 +304,14 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       prod_stats =
         from(acc in PredictionAccuracy, [])
-        |> Filters.stats_by_environment_and_chart_range("prod", %{
-          "chart_range" => "Daily"
-        })
+        |> Filters.stats_by_chart_range(%{"chart_range" => "Daily"})
+        |> where(environment: "prod")
         |> Repo.all()
 
       dev_green_stats =
         from(acc in PredictionAccuracy, [])
-        |> Filters.stats_by_environment_and_chart_range("dev-green", %{
-          "chart_range" => "Daily"
-        })
+        |> Filters.stats_by_chart_range(%{"chart_range" => "Daily"})
+        |> where(environment: "dev-green")
         |> Repo.all()
 
       assert prod_stats == [
@@ -359,9 +355,8 @@ defmodule PredictionAnalyzer.PredictionAccuracy.PredictionAccuracyTest do
 
       prod_stats =
         from(acc in PredictionAccuracy, [])
-        |> Filters.stats_by_environment_and_chart_range("prod", %{
-          "chart_range" => "Hourly"
-        })
+        |> Filters.stats_by_chart_range(%{"chart_range" => "Hourly"})
+        |> where(environment: "prod")
         |> Repo.all()
 
       assert prod_stats == [

--- a/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
+++ b/test/prediction_analyzer_web/controllers/accuracy_controller_test.exs
@@ -42,11 +42,11 @@ defmodule PredictionAnalyzerWeb.AccuracyControllerTest do
 
     Logger.configure(level: old_level)
     assert log =~ "accuracy_context_query_time env=prod"
-    assert log =~ "accuracy_context_query_time env=dev_green"
-    assert log =~ "accuracy_context_query_time env=dev_blue"
+    assert log =~ "accuracy_context_query_time env=dev-green"
+    assert log =~ "accuracy_context_query_time env=dev-blue"
     assert log =~ "accuracies_query_time env=prod"
-    assert log =~ "accuracies_query_time env=dev_green"
-    assert log =~ "accuracies_query_time env=dev_blue"
+    assert log =~ "accuracies_query_time env=dev-green"
+    assert log =~ "accuracies_query_time env=dev-blue"
 
     assert response =~ "From 150 accurate out of 200 total predictions"
     assert response =~ "75.0"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📈🐛 Prediction Analyzer 502s and 504s](https://app.asana.com/1/15492006741476/project/584764604969369/task/1211024184874468?focus=true)

All 6 queries run by the `/accuracy` endpoint now run concurrently. This cuts response time by more than half.

I needed to change `stats_by_environment_and_chart_range/3` to `stats_by_chart_range/2` to have it return an ecto query without the environment filter already baked in. This made it possible to "factor out" the code for the `accuracies` query.

I also tweaked how the filters query is built so that it always filters by `route_id` only once, not up to 3 times redundantly.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
