### PR TITLE
fix: Supply necessary permissions to deploy action

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -24,3 +24,6 @@ jobs:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+    permissions:
+      contents: read
+      id-token: write # Needed to communicate with AWS


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add Zizmor to prediction_analyzer](https://app.asana.com/1/15492006741476/project/584764604969369/task/1215634628813623?focus=true)

Sorry about the extra PR. I was overly optimistic that I had the permissions right the first time and merged without first testing a deploy.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
