### PR TITLE
feat(commuter_rail): add dev-green commuter rail prediction / vehicle position tracking

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,7 @@ config :prediction_analyzer, aws_rds_mod: ExAws.RDS
 config :prediction_analyzer, ecto_repos: [PredictionAnalyzer.Repo]
 config :prediction_analyzer, http_fetcher: HTTPoison
 config :prediction_analyzer, :api_base_url, "https://api-v3.mbta.com/"
+config :prediction_analyzer, :api_dev_green_base_url, "https://api-dev-green.mbtace.com/"
 config :prediction_analyzer, :migration_task, Predictions.ReleaseTasks.NoOp
 config :prediction_analyzer, :stop_name_fetcher, PredictionAnalyzer.StopNameFetcher
 config :prediction_analyzer, :timezone, "America/New_York"

--- a/lib/fake_httpoison.ex
+++ b/lib/fake_httpoison.ex
@@ -108,15 +108,21 @@ defmodule FakeHTTPoison do
   end
 
   def get(
-        "https://api-v3.mbta.com/vehicles",
+        url,
         _,
         timeout: 2000,
         recv_timeout: 2000,
         params: %{
           "filter[route]" =>
             "CR-Fitchburg,CR-Lowell,CR-Haverhill,CR-Newburyport,CR-Worcester,CR-Needham,CR-Franklin,CR-Providence,CR-Fairmount,CR-Middleborough,CR-Kingston,CR-Greenbush,CR-Foxboro"
-        }
-      ) do
+        },
+        env: env
+      )
+      when env in [:prod, :dev_green] and
+             url in [
+               "https://api-v3.mbta.com/vehicles",
+               "https://api-dev-green.mbtace.com/vehicles"
+             ] do
     body = %{
       "data" => [
         %{

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -52,7 +52,9 @@ defmodule PredictionAnalyzer.Predictions.Download do
 
     base_url = Application.get_env(:prediction_analyzer, base_url_var)
 
-    case PredictionAnalyzer.Utilities.APIv3.request(url_path, [params: params], base_url) do
+    case PredictionAnalyzer.Utilities.APIv3.request(url_path, [params: params],
+           base_url: base_url
+         ) do
       {:ok, %{body: body, headers: headers}} ->
         last_modified = headers |> Enum.into(%{}) |> Map.get("last-modified")
 

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -18,6 +18,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
     schedule_dev_green_fetch(self(), initial_dev_green_fetch_ms)
     schedule_dev_blue_fetch(self(), initial_dev_blue_fetch_ms)
     schedule_commuter_rail_fetch(self(), initial_commuter_rail_fetch_ms)
+    schedule_commuter_rail_dev_green_fetch(self(), initial_commuter_rail_fetch_ms)
 
     {:ok, %{}}
   end
@@ -32,8 +33,9 @@ defmodule PredictionAnalyzer.Predictions.Download do
     |> store_subway_predictions(env)
   end
 
-  @spec get_commuter_rail_predictions() :: {integer(), nil | [term()]} | no_return()
-  def get_commuter_rail_predictions() do
+  @spec get_commuter_rail_predictions(String.t()) ::
+          {integer(), nil | [term()]} | no_return()
+  def get_commuter_rail_predictions(env) do
     url_path = "predictions"
 
     params = %{
@@ -42,13 +44,21 @@ defmodule PredictionAnalyzer.Predictions.Download do
       "include" => "vehicle"
     }
 
-    case PredictionAnalyzer.Utilities.APIv3.request(url_path, params: params) do
+    base_url_var =
+      case env do
+        :prod -> :api_base_url
+        :dev_green -> :api_dev_green_base_url
+      end
+
+    base_url = Application.get_env(:prediction_analyzer, base_url_var)
+
+    case PredictionAnalyzer.Utilities.APIv3.request(url_path, [params: params], base_url) do
       {:ok, %{body: body, headers: headers}} ->
         last_modified = headers |> Enum.into(%{}) |> Map.get("last-modified")
 
         body
         |> Jason.decode!()
-        |> store_commuter_rail_predictions(last_modified)
+        |> store_commuter_rail_predictions(env, last_modified)
 
       {:error, e} ->
         Logger.warning("Could not download commuter rail predictions; received: #{inspect(e)}")
@@ -91,7 +101,11 @@ defmodule PredictionAnalyzer.Predictions.Download do
   end
 
   defp schedule_commuter_rail_fetch(pid, ms) do
-    Process.send_after(pid, :get_commuter_rail_predictions, ms)
+    Process.send_after(pid, :get_commuter_rail_prod_predictions, ms)
+  end
+
+  defp schedule_commuter_rail_dev_green_fetch(pid, ms) do
+    Process.send_after(pid, :get_commuter_rail_dev_green_predictions, ms)
   end
 
   def handle_info(:get_prod_predictions, _state) do
@@ -112,9 +126,15 @@ defmodule PredictionAnalyzer.Predictions.Download do
     {:noreply, predictions}
   end
 
-  def handle_info(:get_commuter_rail_predictions, _state) do
+  def handle_info(:get_commuter_rail_prod_predictions, _state) do
     schedule_commuter_rail_fetch(self(), 60_000)
-    predictions = get_commuter_rail_predictions()
+    predictions = get_commuter_rail_predictions(:prod)
+    {:noreply, predictions}
+  end
+
+  def handle_info(:get_commuter_rail_dev_green_predictions, _state) do
+    schedule_commuter_rail_fetch(self(), 60_000)
+    predictions = get_commuter_rail_predictions(:dev_green)
     {:noreply, predictions}
   end
 
@@ -214,7 +234,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
     Filters.kinds() |> Map.get(arrival["uncertainty"] || departure["uncertainty"])
   end
 
-  defp store_commuter_rail_predictions(%{"data" => data}, last_modified) do
+  defp store_commuter_rail_predictions(%{"data" => data}, env, last_modified) do
     {:ok, timestamp} = last_modified |> Timex.parse("{RFC1123}")
     timestamp = DateTime.to_unix(timestamp)
 
@@ -246,7 +266,11 @@ defmodule PredictionAnalyzer.Predictions.Download do
 
           vehicle_id ->
             %{
-              environment: "prod",
+              environment:
+                case env do
+                  :prod -> "prod"
+                  :dev_green -> "dev-green"
+                end,
               file_timestamp: timestamp,
               vehicle_id: vehicle_id,
               trip_id: prediction["relationships"]["trip"]["data"]["id"],
@@ -266,7 +290,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
     {_, _} = PredictionAnalyzer.Repo.insert_all(Prediction, predictions)
   end
 
-  defp store_commuter_rail_predictions(_, _) do
+  defp store_commuter_rail_predictions(_, _, _) do
     nil
   end
 end

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -33,7 +33,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
     |> store_subway_predictions(env)
   end
 
-  @spec get_commuter_rail_predictions(String.t()) ::
+  @spec get_commuter_rail_predictions(:prod | :dev_green) ::
           {integer(), nil | [term()]} | no_return()
   def get_commuter_rail_predictions(env) do
     url_path = "predictions"

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -52,7 +52,8 @@ defmodule PredictionAnalyzer.Predictions.Download do
 
     base_url = Application.get_env(:prediction_analyzer, base_url_var)
 
-    case PredictionAnalyzer.Utilities.APIv3.request(url_path, [params: params],
+    case PredictionAnalyzer.Utilities.APIv3.request(url_path,
+           params: params,
            base_url: base_url
          ) do
       {:ok, %{body: body, headers: headers}} ->

--- a/lib/prediction_analyzer/predictions/download.ex
+++ b/lib/prediction_analyzer/predictions/download.ex
@@ -135,7 +135,7 @@ defmodule PredictionAnalyzer.Predictions.Download do
   end
 
   def handle_info(:get_commuter_rail_dev_green_predictions, _state) do
-    schedule_commuter_rail_fetch(self(), 60_000)
+    schedule_commuter_rail_dev_green_fetch(self(), 60_000)
     predictions = get_commuter_rail_predictions(:dev_green)
     {:noreply, predictions}
   end

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -96,10 +96,6 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     end
   end
 
-  def handle_info(:track_commuter_rail_vehicles, %{environment: "dev-green"} = state) do
-    {:noreply, state}
-  end
-
   def handle_info(:track_commuter_rail_vehicles, %{environment: "dev-blue"} = state) do
     {:noreply, state}
   end
@@ -114,18 +110,25 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
 
     schedule_commuter_rail_fetch(self())
 
+    env =
+      case state.environment do
+        "dev-green" -> :dev_green
+        _ -> :prod
+      end
+
     state =
       case PredictionAnalyzer.Utilities.APIv3.request(
              url_path,
              [{"If-Modified-Since", state.commuter_rail_last_modified}],
-             params: params
+             params: params,
+             env: env
            ) do
         {:ok, %{body: body, headers: headers}} ->
           new_vehicles =
             body
             |> Jason.decode!()
             |> Map.get("data")
-            |> parse_commuter_rail("prod")
+            |> parse_commuter_rail(state.environmnt)
             |> Enum.into(%{}, fn v -> {v.id, v} end)
             |> Comparator.compare(state.commuter_rail_vehicles)
 

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -128,7 +128,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
             body
             |> Jason.decode!()
             |> Map.get("data")
-            |> parse_commuter_rail(state.environmnt)
+            |> parse_commuter_rail(state.environment)
             |> Enum.into(%{}, fn v -> {v.id, v} end)
             |> Comparator.compare(state.commuter_rail_vehicles)
 

--- a/lib/prediction_analyzer/vehicle_positions/tracker.ex
+++ b/lib/prediction_analyzer/vehicle_positions/tracker.ex
@@ -189,9 +189,9 @@ defmodule PredictionAnalyzer.VehiclePositions.Tracker do
     []
   end
 
-  defp parse_commuter_rail(data, _env) do
+  defp parse_commuter_rail(data, env) do
     Enum.flat_map(data, fn d ->
-      case Vehicle.parse_commuter_rail(d) do
+      case Vehicle.parse_commuter_rail(d, env) do
         {:ok, vehicle} -> [vehicle]
         _ -> []
       end

--- a/lib/prediction_analyzer/vehicle_positions/vehicle.ex
+++ b/lib/prediction_analyzer/vehicle_positions/vehicle.ex
@@ -127,7 +127,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
      }}
   end
 
-  def parse_commuter_rail(_, env), do: :error
+  def parse_commuter_rail(_, _env), do: :error
 
   defp status_atom("INCOMING_AT"), do: :INCOMING_AT
   defp status_atom("IN_TRANSIT_TO"), do: :IN_TRANSIT_TO

--- a/lib/prediction_analyzer/vehicle_positions/vehicle.ex
+++ b/lib/prediction_analyzer/vehicle_positions/vehicle.ex
@@ -81,38 +81,41 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
     :error
   end
 
-  def parse_commuter_rail(%{
-        "attributes" => %{
-          "current_status" => current_status,
-          "direction_id" => direction_id,
-          "label" => label,
-          "updated_at" => updated_at
-        },
-        "id" => vehicle_id,
-        "relationships" => %{
-          "route" => %{
-            "data" => %{
-              "id" => route_id
-            }
+  def parse_commuter_rail(
+        %{
+          "attributes" => %{
+            "current_status" => current_status,
+            "direction_id" => direction_id,
+            "label" => label,
+            "updated_at" => updated_at
           },
-          "stop" => %{
-            "data" => %{
-              "id" => stop_id
-            }
-          },
-          "trip" => %{
-            "data" => %{
-              "id" => trip_id
+          "id" => vehicle_id,
+          "relationships" => %{
+            "route" => %{
+              "data" => %{
+                "id" => route_id
+              }
+            },
+            "stop" => %{
+              "data" => %{
+                "id" => stop_id
+              }
+            },
+            "trip" => %{
+              "data" => %{
+                "id" => trip_id
+              }
             }
           }
-        }
-      }) do
+        },
+        env
+      ) do
     {:ok, timestamp, _offset} = updated_at |> DateTime.from_iso8601()
 
     {:ok,
      %__MODULE__{
        id: vehicle_id,
-       environment: "prod",
+       environment: env,
        label: label,
        is_deleted: false,
        trip_id: trip_id,
@@ -124,7 +127,7 @@ defmodule PredictionAnalyzer.VehiclePositions.Vehicle do
      }}
   end
 
-  def parse_commuter_rail(_), do: :error
+  def parse_commuter_rail(_, env), do: :error
 
   defp status_atom("INCOMING_AT"), do: :INCOMING_AT
   defp status_atom("IN_TRANSIT_TO"), do: :IN_TRANSIT_TO

--- a/lib/utilities/api_v3.ex
+++ b/lib/utilities/api_v3.ex
@@ -14,7 +14,7 @@ defmodule PredictionAnalyzer.Utilities.APIv3 do
     http_fetcher = Application.get_env(:prediction_analyzer, :http_fetcher)
 
     base_url =
-      Keyword.get(opts, :base_url) || Application.get_env(:prediction_analzer, :api_base_url)
+      Keyword.get(opts, :base_url) || Application.get_env(:prediction_analyzer, :api_base_url)
 
     opts = Keyword.delete(opts, :base_url)
 

--- a/lib/utilities/api_v3.ex
+++ b/lib/utilities/api_v3.ex
@@ -3,9 +3,12 @@ defmodule PredictionAnalyzer.Utilities.APIv3 do
 
   @spec request(String.t(), [{String.t(), String.t()}], Keyword.t()) ::
           {:error, any()} | {:ok, map()}
-  def request(path, extra_headers \\ [], opts) do
-    base_url = Application.get_env(:prediction_analyzer, :api_base_url)
-
+  def request(
+        path,
+        extra_headers \\ [],
+        base_url \\ Application.get_env(:prediction_analyzer, :api_base_url),
+        opts
+      ) do
     headers =
       extra_headers ++ api_key_headers(Application.get_env(:prediction_analyzer, :api_v3_key))
 

--- a/lib/utilities/api_v3.ex
+++ b/lib/utilities/api_v3.ex
@@ -8,13 +8,22 @@ defmodule PredictionAnalyzer.Utilities.APIv3 do
         extra_headers \\ [],
         opts
       ) do
+    env = Keyword.get(opts, :env)
+
+    {base_url, api_key_headers} =
+      case env do
+        :dev_green ->
+          {Application.get_env(:prediction_analyzer, :api_dev_green_base_url), []}
+
+        _ ->
+          {Application.get_env(:prediction_analyzer, :api_base_url),
+           api_key_headers(Application.get_env(:prediction_analyzer, :api_v3_key))}
+      end
+
     headers =
-      extra_headers ++ api_key_headers(Application.get_env(:prediction_analyzer, :api_v3_key))
+      extra_headers ++ api_key_headers
 
     http_fetcher = Application.get_env(:prediction_analyzer, :http_fetcher)
-
-    base_url =
-      Keyword.get(opts, :base_url) || Application.get_env(:prediction_analyzer, :api_base_url)
 
     opts = Keyword.delete(opts, :base_url)
 

--- a/lib/utilities/api_v3.ex
+++ b/lib/utilities/api_v3.ex
@@ -6,13 +6,17 @@ defmodule PredictionAnalyzer.Utilities.APIv3 do
   def request(
         path,
         extra_headers \\ [],
-        base_url \\ Application.get_env(:prediction_analyzer, :api_base_url),
         opts
       ) do
     headers =
       extra_headers ++ api_key_headers(Application.get_env(:prediction_analyzer, :api_v3_key))
 
     http_fetcher = Application.get_env(:prediction_analyzer, :http_fetcher)
+
+    base_url =
+      Keyword.get(opts, :base_url) || Application.get_env(:prediction_analzer, :api_base_url)
+
+    opts = Keyword.delete(opts, :base_url)
 
     with {:ok, req} <-
            http_fetcher.get(

--- a/test/prediction_analyzer/predictions/download_test.exs
+++ b/test/prediction_analyzer/predictions/download_test.exs
@@ -99,16 +99,18 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
       assert log =~ "Could not download commuter rail predictions"
     end
 
-    test "downloads and stores prod predictions" do
-      Download.get_commuter_rail_predictions(:prod)
-      query = from(p in Prediction, select: [p.stop_id, p.direction_id, p.vehicle_id])
+    for env <- [:dev_green, :prod] do
+      test "downloads and stores #{env} predictions" do
+        Download.get_commuter_rail_predictions(unquote(env))
+        query = from(p in Prediction, select: [p.stop_id, p.direction_id, p.vehicle_id])
 
-      preds = PredictionAnalyzer.Repo.all(query)
+        preds = PredictionAnalyzer.Repo.all(query)
 
-      assert preds == [
-               ["North Station", 0, "vehicle_id"],
-               ["North Station", 0, "vehicle_id"]
-             ]
+        assert preds == [
+                 ["North Station", 0, "vehicle_id"],
+                 ["North Station", 0, "vehicle_id"]
+               ]
+      end
     end
   end
 

--- a/test/prediction_analyzer/predictions/download_test.exs
+++ b/test/prediction_analyzer/predictions/download_test.exs
@@ -31,7 +31,8 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
 
       assert_received :get_prod_predictions
       assert_received :get_dev_green_predictions
-      assert_received :get_commuter_rail_predictions
+      assert_received :get_commuter_rail_prod_predictions
+      assert_received :get_commuter_rail_dev_green_predictions
     end
   end
 
@@ -81,13 +82,13 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
     end
   end
 
-  describe "get_commuter_rail_predictions/0" do
+  describe "get_commuter_rail_predictions/1" do
     test "when theres an error, gets no predictions" do
       reassign_env(:http_fetcher, FailedHTTPFetcher)
 
       log =
         capture_log([level: :warning], fn ->
-          Download.get_commuter_rail_predictions()
+          Download.get_commuter_rail_predictions(:prod)
         end)
 
       query = from(p in Prediction, select: [p.stop_id, p.direction_id, p.vehicle_id])
@@ -99,7 +100,7 @@ defmodule PredictionAnalyzer.Predictions.DownloadTest do
     end
 
     test "downloads and stores prod predictions" do
-      Download.get_commuter_rail_predictions()
+      Download.get_commuter_rail_predictions(:prod)
       query = from(p in Prediction, select: [p.stop_id, p.direction_id, p.vehicle_id])
 
       preds = PredictionAnalyzer.Repo.all(query)

--- a/test/prediction_analyzer/vehicle_positions/tracker_test.exs
+++ b/test/prediction_analyzer/vehicle_positions/tracker_test.exs
@@ -204,35 +204,37 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
   end
 
   describe "handle_info :track_commuter_rail_vehicles" do
-    test "updates the state with new vehicles and a new last-modified time" do
-      state = %{
-        aws_vehicle_positions_url: "vehiclepositions",
-        environment: "prod",
-        subway_vehicles: %{},
-        commuter_rail_vehicles: %{},
-        commuter_rail_last_modified: "Thu, 01 Jan 1970 00:00:00 GMT"
-      }
+    for env <- ["dev-green", "prod"] do
+      test "updates the #{env} state with new vehicles and a new last-modified time" do
+        state = %{
+          aws_vehicle_positions_url: "vehiclepositions",
+          environment: unquote(env),
+          subway_vehicles: %{},
+          commuter_rail_vehicles: %{},
+          commuter_rail_last_modified: "Thu, 01 Jan 1970 00:00:00 GMT"
+        }
 
-      assert {
-               :noreply,
-               %{
-                 commuter_rail_vehicles: %{
-                   "1629" => %PredictionAnalyzer.VehiclePositions.Vehicle{
-                     current_status: :IN_TRANSIT_TO,
-                     direction_id: 1,
-                     environment: "prod",
-                     id: "1629",
-                     is_deleted: false,
-                     label: "1629",
-                     route_id: "CR-Lowell",
-                     stop_id: "North Station",
-                     timestamp: 1_553_795_877,
-                     trip_id: "CR-Weekday-Fall-18-324"
-                   }
-                 },
-                 commuter_rail_last_modified: "Sat, 10 Sep 1977 08:25:00 GMT"
-               }
-             } = Tracker.handle_info(:track_commuter_rail_vehicles, state)
+        assert {
+                 :noreply,
+                 %{
+                   commuter_rail_vehicles: %{
+                     "1629" => %PredictionAnalyzer.VehiclePositions.Vehicle{
+                       current_status: :IN_TRANSIT_TO,
+                       direction_id: 1,
+                       environment: unquote(env),
+                       id: "1629",
+                       is_deleted: false,
+                       label: "1629",
+                       route_id: "CR-Lowell",
+                       stop_id: "North Station",
+                       timestamp: 1_553_795_877,
+                       trip_id: "CR-Weekday-Fall-18-324"
+                     }
+                   },
+                   commuter_rail_last_modified: "Sat, 10 Sep 1977 08:25:00 GMT"
+                 }
+               } = Tracker.handle_info(:track_commuter_rail_vehicles, state)
+      end
     end
 
     test "handles 304s (Not Modified) gracefully" do
@@ -293,10 +295,10 @@ defmodule PredictionAnalyzer.VehiclePositions.TrackerTest do
       assert log =~ "Could not download commuter rail vehicles"
     end
 
-    test "does nothing on dev-green" do
+    test "does nothing on dev-blue" do
       state = %{
         aws_vehicle_positions_url: "vehiclepositions",
-        environment: "dev-green",
+        environment: "dev-blue",
         subway_vehicles: %{},
         commuter_rail_vehicles: %{}
       }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📈🚆 Add environment to PA to see CR staging predictions](https://app.asana.com/1/15492006741476/project/584764604969369/task/1214237801242504?focus=true)

Problem:
Keolis is upgrading TransitVision, their realtime vehicle position provider (among other functions) to a new version. This version is running against the `mbta-cr-test` Swiftly environment, which is currently hooked up to `dev-green` Concentrate / API. But we don't have any way to evaluate prediction accuracy for that envrionment.

Solution:
Add tracking for dev-green Commuter Rail predictions to `prediction_analyzer`.

This is currently running [on dev. ](https://prediction-analyzer-dev.mbtace.com/accuracy?filters[bin]=All&filters[chart_range]=Hourly&filters[direction_id]=any&filters[mode]=commuter_rail&filters[route_ids]=&filters[service_date]=2026-07-24&filters[timeframe_resolution]=60). Maybe surprisingly, it doesn't seem like we get rate limited on dev-green without an API key.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
